### PR TITLE
Revert "Better to return closure function"

### DIFF
--- a/src/Riari/Forum/Libraries/AccessControl.php
+++ b/src/Riari/Forum/Libraries/AccessControl.php
@@ -24,7 +24,7 @@ class AccessControl {
         if (!$permission_granted && $abort)
         {
             $denied_callback = config('forum.integration.process_denied');
-            return  $denied_callback($context, $user);
+            $denied_callback($context, $user);
         }
 
         return $permission_granted;


### PR DESCRIPTION
Reverts Riari/laravel-forum#47

@mikield: Sorry, I just realised I should not have merged this because the check() method is designed to always return a bool, and not the response of a callback. The callback is really there to throw an exception, if anything.

I'm open to alternatives, but that method must remain as it was.
