### PR TITLE
re-add config for forum.integration.user_name in config/integration.php

### DIFF
--- a/config/integration.php
+++ b/config/integration.php
@@ -32,4 +32,15 @@ return [
 
     'user_model' => App\User::class,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Application user name
+    |--------------------------------------------------------------------------
+    |
+    | The attribute to use for the username.
+    |
+    */
+
+    'user_name' => 'name',
+
 ];


### PR DESCRIPTION
hi riari!

i think you were a bit too thourough in your last restructuring, since you also removed the config for 'user_name' in config/integration.php. it is however used in Models/Traits/HasAuthor.php and it's absence breaks the frontend output.

apologies, if this was intended and/or part of further restructurings.

best wishes,
gerald
