### PR TITLE
Removed unnecessary use statements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,10 @@ Run your migrations:
 
 ### Additional steps
 
+#### Server configuration
+
+> If you installed Xdebug before version 2.3, you may need to modify `xdebug.max_nesting_level`. The suggested and new default value from version 2.3 onwards is `256`.
+
 #### Configuration
 
 Several configuration files are published to your application's config directory, each prefixed with `forum.`. Refer to these for a variety of options for changing the behaviour of the forum and how it integrates with key parts of your application code.

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -3,8 +3,6 @@
 namespace Riari\Forum\Models;
 
 use Illuminate\Support\Facades\Gate;
-use Riari\Forum\Models\Category;
-use Riari\Forum\Models\Thread;
 use Riari\Forum\Models\Traits\HasSlug;
 use Riari\Forum\Support\Traits\CachesData;
 

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -3,8 +3,6 @@
 namespace Riari\Forum\Models;
 
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Riari\Forum\Models\Post;
-use Riari\Forum\Models\Thread;
 use Riari\Forum\Models\Traits\HasAuthor;
 
 class Post extends BaseModel


### PR DESCRIPTION
Causes IDE to panic and are not being used

Ok... so pull requests on github are new to me. I didn't mean to have the other commit included in here. The other one is an addition to the readme to mention xdebug max nesting level, those using xdebug will most likely run into the issue when installing.
