### PR TITLE
Fixed migration error

### DIFF
--- a/migrations/2016_05_24_114302_add_defaults_to_forum_table_threads_columns.php
+++ b/migrations/2016_05_24_114302_add_defaults_to_forum_table_threads_columns.php
@@ -14,8 +14,8 @@ class AddDefaultsToForumTableThreadsColumns extends Migration
     {
         Schema::table('forum_threads', function (Blueprint $table)
         {
-            $table->column('pinned')->nullable()->default(0)->change();
-            $table->column('locked')->nullable()->default(0)->change();
+            $table->boolean('pinned')->nullable()->default(0)->change();
+            $table->boolean('locked')->nullable()->default(0)->change();
         });
     }
 
@@ -28,8 +28,8 @@ class AddDefaultsToForumTableThreadsColumns extends Migration
     {
         Schema::table('forum_threads', function (Blueprint $table)
         {
-            $table->column('pinned')->nullable(false)->default(null)->change();
-            $table->column('locked')->nullable(false)->default(null)->change();
+            $table->boolean('pinned')->nullable(false)->default(null)->change();
+            $table->boolean('locked')->nullable(false)->default(null)->change();
         });
     }
 }


### PR DESCRIPTION
Changes made to fix the following error:
[Symfony\Component\Debug\Exception\FatalThrowableError]
Fatal error: Call to undefined method Illuminate\Database\Schema\Blueprint::column()
