### PR TITLE
added support for paging via API methods

### DIFF
--- a/config/preferences.php
+++ b/config/preferences.php
@@ -25,9 +25,10 @@ return [
     */
 
     'pagination' => [
-        'categories'    => 20, // Categories per page (API only)
-        'threads'       => 20, // Threads per page
-        'posts'         => 15  // Posts per page
+        'enabled'       => false, // enables pagination (API only)
+        'categories'    => 20, // Categories per page (API only), 0 disables the paging
+        'threads'       => 20, // Threads per page, 0 disables the paging
+        'posts'         => 15  // Posts per page, 0 disables the paging
     ],
 
     /*

--- a/src/Http/Controllers/API/BaseController.php
+++ b/src/Http/Controllers/API/BaseController.php
@@ -351,14 +351,15 @@ abstract class BaseController extends Controller
      */
     protected function runResponseQuery($query, $configKeyForPaginate, $handleCollectionCallback = null)
     {
+
         // check if paging is enabled and not zero
         $perPage = $this->getPerPageForConfigKey($configKeyForPaginate);
 
         if ($perPage > 0) {
             // run the paginate
-            $response = $query->paginate($perPage);
+            $response = $this->runPaginateQuery($query, $perPage);
         } else {
-            $response = $query->get();
+            $response = $this->runGetQuery($query);
         }
 
         // adapt the data by custom logic (for paginate not ideal...)
@@ -367,6 +368,31 @@ abstract class BaseController extends Controller
         }
 
         return $response;
+    }
+
+    /**
+     * Runs the paginate query
+     *
+     * @param Builder $query
+     * @param int $perPage
+     *
+     * @return AbstractPaginator
+     */
+    protected function runPaginateQuery($query, $perPage)
+    {
+        return $query->paginate($perPage);
+    }
+
+    /**
+     * Runs the get query
+     *
+     * @param Builder $query
+     *
+     * @return Collection
+     */
+    protected function runGetQuery($query)
+    {
+        return $query->get();
     }
 
     /**

--- a/src/Http/Controllers/API/CategoryController.php
+++ b/src/Http/Controllers/API/CategoryController.php
@@ -38,7 +38,7 @@ class CategoryController extends BaseController
         $categoriesQuery = $this->model()->withRequestScopes($request);
 
         // the paging will not receive ideal count
-        return $this->responseWithQueryAndFilter($categoriesQuery, "categories", function ($category) {
+        return $this->responseWithQueryAndFilter($request, $categoriesQuery, "categories", function ($category) {
             if ($category->private) {
                 return Gate::allows('view', $category);
             }

--- a/src/Http/Controllers/API/CategoryController.php
+++ b/src/Http/Controllers/API/CategoryController.php
@@ -35,17 +35,16 @@ class CategoryController extends BaseController
      */
     public function index(Request $request)
     {
-        $categories = $this->model()->withRequestScopes($request);
+        $categoriesQuery = $this->model()->withRequestScopes($request);
 
-        $categories = $categories->get()->filter(function ($category) {
+        // the paging will not receive ideal count
+        return $this->responseWithQueryAndFilter($categoriesQuery, "categories", function ($category) {
             if ($category->private) {
                 return Gate::allows('view', $category);
             }
 
             return true;
         });
-
-        return $this->response($categories);
     }
 
     /**

--- a/src/Http/Controllers/API/PostController.php
+++ b/src/Http/Controllers/API/PostController.php
@@ -37,9 +37,10 @@ class PostController extends BaseController
     {
         $this->validate($request, ['thread_id' => ['required']]);
 
-        $posts = $this->model()->where('thread_id', $request->input('thread_id'))->get();
-
-        return $this->response($posts);
+        return $this->responseWithQuery(
+            $this->model()->where('thread_id', $request->input('thread_id')),
+            "posts"
+        );
     }
 
     /**

--- a/src/Http/Controllers/API/PostController.php
+++ b/src/Http/Controllers/API/PostController.php
@@ -38,7 +38,7 @@ class PostController extends BaseController
         $this->validate($request, ['thread_id' => ['required']]);
 
         return $this->responseWithQuery(
-            $this->model()->where('thread_id', $request->input('thread_id')),
+            $this->model()->withRequestScopes($request)->where('thread_id', $request->input('thread_id')),
             "posts"
         );
     }

--- a/src/Http/Controllers/API/ThreadController.php
+++ b/src/Http/Controllers/API/ThreadController.php
@@ -32,19 +32,20 @@ class ThreadController extends BaseController
     /**
      * GET: return an index of threads by category ID.
      *
-     * @param  Request  $request
+     * @param  Request $request
+     *
      * @return JsonResponse|Response
      */
     public function index(Request $request)
     {
         $this->validate($request, ['category_id' => ['required']]);
 
-        $threads = $this->model()
-            ->withRequestScopes($request)
-            ->where('category_id', $request->input('category_id'))
-            ->get();
-
-        return $this->response($threads);
+        return $this->responseWithQuery(
+            $this->model()
+                ->withRequestScopes($request)
+                ->where('category_id', $request->input('category_id')),
+            "threads"
+        );
     }
 
     /**

--- a/src/Http/Controllers/API/ThreadController.php
+++ b/src/Http/Controllers/API/ThreadController.php
@@ -41,8 +41,8 @@ class ThreadController extends BaseController
         $this->validate($request, ['category_id' => ['required']]);
 
         return $this->responseWithQuery(
+            $request,
             $this->model()
-                ->withRequestScopes($request)
                 ->where('category_id', $request->input('category_id')),
             "threads"
         );

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -1,5 +1,6 @@
 <?php namespace Riari\Forum\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 
@@ -113,6 +114,22 @@ abstract class BaseModel extends Model
     public function withRequestScopes(Request $request)
     {
         return $this->requestWhere($request)->requestWith($request)->requestAppend($request)->requestOrder($request);
+    }
+
+    /**
+     * Helper: Apply request-based scopes to the model query.
+     *
+     * @param Builder $builder
+     * @param Request $request
+     *
+     * @return Model
+     */
+    public function scopeWithRequestScopes($builder, Request $request)
+    {
+        return $this->scopeRequestWhere($builder, $request)
+                    ->requestWith($request)
+                    ->requestAppend($request)
+                    ->requestOrder($request);
     }
 
     /**

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -1,9 +1,15 @@
 <?php namespace Riari\Forum\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Riari\Forum\Models\Traits\HasAuthor;
 use Riari\Forum\Support\Traits\CachesData;
 
+/**
+ * @property Collection children
+ * @property Thread     thread
+ * @property int        id
+ */
 class Post extends BaseModel
 {
     use SoftDeletes, HasAuthor, CachesData;

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -1,5 +1,6 @@
 <?php namespace Riari\Forum\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Gate;
 use Riari\Forum\Models\Category;
@@ -7,6 +8,10 @@ use Riari\Forum\Models\Post;
 use Riari\Forum\Models\Traits\HasAuthor;
 use Riari\Forum\Support\Traits\CachesData;
 
+/**
+ * @property Collection posts
+ * @property Post       firstPost
+ */
 class Thread extends BaseModel
 {
     use SoftDeletes, HasAuthor, CachesData;


### PR DESCRIPTION
Hi,
I’ve noticed that paging doesn’t work on API methods (not implemented). I’ve added support to enable paging on the API calls (thread, categories, posts). Only category list is not perfect - there is a filter which removes private categories after the query is done. The paginate will return data, but the total count is not accurate (based on the private settings).

We can disable paging for categories by setting 0.

To enable paging set `true` in the config: `forum.preferences.pagination.enabled`
