### PR TITLE
Added the pivot table in the where clause

### DIFF
--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -166,7 +166,7 @@ class Thread extends BaseModel
     public function getReaderAttribute()
     {
         if (auth()->check()) {
-            $reader = $this->readers()->where('user_id', auth()->user()->getKey())->first();
+            $reader = $this->readers()->where('forum_threads_read.user_id', auth()->user()->getKey())->first();
 
             return (!is_null($reader)) ? $reader->pivot : null;
         }


### PR DESCRIPTION
Using a custom primary id of "user_id" in the User's model causes an integrity constraint violation because the "user_id" is ambiguous.

I've added the table name to clear up the ambiguity issue.