### PR TITLE
Set the `foreign_key` attribute on the author belongsTo method

### DIFF
--- a/src/Models/Traits/HasAuthor.php
+++ b/src/Models/Traits/HasAuthor.php
@@ -9,7 +9,7 @@ trait HasAuthor
      */
     public function author()
     {
-        return $this->belongsTo(config('forum.integration.user_model'));
+        return $this->belongsTo(config('forum.integration.user_model'), 'author_id');
     }
 
     /**


### PR DESCRIPTION
When the user model has a custom primary key (e.g `user_id` instead of `id`) Laravel will attempt to guess the foreign key and local key on a `belongsTo` relationship. However if guesses incorrectly.

In the case where the foreign key is `user_id` Laravel 5.4 will interpret the foreign key as `author_user_id`. Manually setting the foregin key to `author_id` fixes this.