### PR TITLE
Fix bug with force-deleting threads and posts

### DIFF
--- a/src/Models/Observers/PostObserver.php
+++ b/src/Models/Observers/PostObserver.php
@@ -36,7 +36,7 @@ class PostObserver
 
         if ($post->thread->posts->isEmpty()) {
             // The containing thread is now empty, so delete the thread accordingly
-            if ($post->deleted_at->toDateTimeString() != Carbon::now()->toDateTimeString()) {
+            if (!$post->deleted_at || $post->deleted_at->toDateTimeString() !== Carbon::now()->toDateTimeString()) {
                 // The post was force-deleted, so the thread should be too
                 $post->thread()->withTrashed()->forceDelete();
             } else {

--- a/src/Models/Observers/ThreadObserver.php
+++ b/src/Models/Observers/ThreadObserver.php
@@ -32,7 +32,7 @@ class ThreadObserver
     public function deleted($thread)
     {
         // Delete the thread's posts
-        if ($thread->deleted_at->toDateTimeString() != Carbon::now()->toDateTimeString()) {
+        if (!$thread->deleted_at || $thread->deleted_at->toDateTimeString() !== Carbon::now()->toDateTimeString()) {
             // The thread was force-deleted, so the posts should be too
             $thread->posts()->withTrashed()->forceDelete();
 

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -15,6 +15,11 @@ class Post extends BaseModel
      */
     protected $table = 'forum_posts';
 
+    /**
+     * @var array
+     */
+    protected $dates = ['deleted_at'];
+
 	/**
 	 * The attributes that are mass assignable.
 	 *

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -17,6 +17,11 @@ class Thread extends BaseModel
     protected $table = 'forum_threads';
 
     /**
+     * @var array
+     */
+    protected $dates = ['deleted_at'];
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array


### PR DESCRIPTION
**Fix for https://github.com/Riari/laravel-forum/pull/188**

When force-deleting thread or post its fails with error:

> Call to a member function toDateTimeString() on null

or

> Call to a member function toDateTimeString() on string

The reason is the field `deleted_at` can be only `null` (if model was not deleted before) or `string` (if there is some value in the `deleted_at`).

I fixed this problem.