### PR TITLE
Fixes error on model deletion

### DIFF
--- a/src/Http/Controllers/API/BaseController.php
+++ b/src/Http/Controllers/API/BaseController.php
@@ -204,6 +204,9 @@ abstract class BaseController extends Controller
         $this->parseAuthorization($model, $authorize);
 
         if ($force) {
+            if($model->deleted_at == null) {
+                $model->delete();
+            }
             $model->forceDelete();
 
             return $this->response($model, $this->trans('perma_deleted'));


### PR DESCRIPTION
Fixes `Call to a member function toDateTimeString()` error called from `Riari\Forum\Models\Observers\ThreadObserver->deleted` when a thread is permanently deleted and the `deleted_at` field is `null`