### PR TITLE
Don't touch updated_at for pinned, locked, and category_id attributes

### DIFF
--- a/src/Http/Controllers/API/BaseController.php
+++ b/src/Http/Controllers/API/BaseController.php
@@ -13,6 +13,8 @@ abstract class BaseController extends Controller
 {
     use AuthorizesRequests, ValidatesRequests;
 
+    const ATTRS_WITHOUT_TIMESTAMP = ['pinned', 'locked', 'category_id'];
+
     /**
      * @var Request
      */
@@ -181,6 +183,10 @@ abstract class BaseController extends Controller
         }
 
         $this->parseAuthorization($model, $authorize);
+
+        if (!empty(array_intersect(array_keys($attributes), BaseController::ATTRS_WITHOUT_TIMESTAMP))) {
+            $model->timestamps = false;
+        }
 
         $model->update($attributes);
 


### PR DESCRIPTION
This PR prevents touching `updated_at` field when updating `pinned` and `locked` attributes of the `Thread` model, and `category_id` on `Thread` and `Category` models.

If the `updated_at` attribute was updated, users would see new activity in the thread but there would be no new posts creating confusion.

Closes #197 