### PR TITLE
Add last_replied_at column to threads table

### DIFF
--- a/migrations/2018_10_16_211732_add_last_replied_at_to_threads_table.php
+++ b/migrations/2018_10_16_211732_add_last_replied_at_to_threads_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddLastRepliedAtToThreadsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('forum_threads', function (Blueprint $table) {
+            $table->timestamp('last_replied_at')->nullable()->after('reply_count');
+        });
+
+        DB::table('forum_threads')->where('reply_count', '>', 0)->update(['last_replied_at' => DB::raw('`updated_at`')]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('forum_threads', function (Blueprint $table) {
+            $table->dropColum('last_replied_at');
+        });
+    }
+}

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -121,7 +121,7 @@ abstract class BaseModel extends Model
      * @param  Model  $model
      * @return boolean
      */
-    public function updatedSince(&$model)
+    public function updatedSince(Model $model)
     {
         return ($this->updated_at > $model->updated_at);
     }

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -98,7 +98,10 @@ class Category extends BaseModel
      */
     public function getThreadsPaginatedAttribute()
     {
-        return $this->threads()->orderBy('pinned', 'desc')->orderBy('updated_at', 'desc')
+        return $this->threads()
+            ->orderBy('pinned', 'desc')
+            ->orderBy('last_replied_at', 'desc')
+            ->orderBy('created_at', 'desc')
             ->paginate(config('forum.preferences.pagination.threads'));
     }
 

--- a/src/Models/Observers/PostObserver.php
+++ b/src/Models/Observers/PostObserver.php
@@ -7,8 +7,8 @@ class PostObserver
 {
     public function created($post)
     {
-        // Update the thread's updated_at timestamp to match the created_at timestamp of the new post
-        $post->thread->updated_at = $post->created_at;
+        // Update the thread's last_replied_at timestamps to match the created_at timestamp of the new post
+        $post->thread->last_replied_at = $post->created_at;
         $post->thread->save();
 
         // Set the post's sequence number
@@ -51,8 +51,8 @@ class PostObserver
             $post->saveWithoutTouch();
         });
 
-        // Update the thread's updated_at timestamp to match the created_at timestamp of its latest post
-        $post->thread->updated_at = $post->thread->lastPostTime;
+        // Update the thread's last_replied_at timestamps to match the created_at timestamp of its latest post
+        $post->thread->last_replied_at = $post->thread->lastPostTime;
         $post->thread->save();
 
         Stats::updateThread($post->thread);

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -1,5 +1,6 @@
 <?php namespace Riari\Forum\Models;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Gate;
 use Riari\Forum\Models\Category;
@@ -19,7 +20,7 @@ class Thread extends BaseModel
     /**
      * @var array
      */
-    protected $dates = ['deleted_at'];
+    protected $dates = ['last_replied_at', 'deleted_at'];
 
     /**
      * The attributes that are mass assignable.
@@ -98,7 +99,7 @@ class Thread extends BaseModel
         $age = strtotime(config('forum.preferences.old_thread_threshold'), 0);
         $cutoff = $time - $age;
 
-        return $query->where('updated_at', '>', date('Y-m-d H:i:s', $cutoff))->orderBy('updated_at', 'desc');
+        return $query->where('last_replied_at', '>', date('Y-m-d H:i:s', $cutoff))->orderBy('last_replied_at', 'desc');
     }
 
     /**
@@ -160,7 +161,7 @@ class Thread extends BaseModel
     public function getOldAttribute()
     {
         $age = config('forum.preferences.old_thread_threshold');
-        return (!$age || $this->updated_at->timestamp < (time() - strtotime($age, 0)));
+        return (!$age || $this->last_replied_at && $this->last_replied_at->timestamp < (time() - strtotime($age, 0)));
     }
 
     /**
@@ -191,10 +192,21 @@ class Thread extends BaseModel
                 return self::STATUS_UNREAD;
             }
 
-            return ($this->updatedSince($this->reader)) ? self::STATUS_UPDATED : false;
+            return $this->repliedToSince($this->reader) ? self::STATUS_UPDATED : false;
         }
 
         return false;
+    }
+
+    /**
+     * Helper: Determine if this thread has been replied to since the given model was updated.
+     *
+     * @param  Model  $model
+     * @return boolean
+     */
+    public function repliedToSince(Model $model)
+    {
+        return ($this->last_replied_at > $model->updated_at);
     }
 
     /**
@@ -208,7 +220,7 @@ class Thread extends BaseModel
         if (!$this->old) {
             if (is_null($this->reader)) {
                 $this->readers()->attach($userID);
-            } elseif ($this->updatedSince($this->reader)) {
+            } elseif ($this->repliedToSince($this->reader)) {
                 $this->reader->touch();
             }
         }


### PR DESCRIPTION
@Gummibeer I'd be grateful for your input again :)

I know you mentioned the BC nature of this change and I'm considering a major version bump to 5.0 for that reason. If I do that, I might as well take advantage of the opportunity and do the following as well:

- Go through all of the code to take full advantage of PHP 7 (e.g. add return types)
- Require a minimum PHP version of 7.0.0
- Change the category schema to something more appropriate for tree data (e.g. nested set or materialised path)

I can give the frontend a similar treatment (I'm actually already in the process of giving it a new Bootstrap 4 look).

What do you think?