### PR TITLE
Sort thread posts by created date

### DIFF
--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -82,7 +82,7 @@ class Thread extends BaseModel
     public function posts()
     {
         $withTrashed = config('forum.preferences.display_trashed_posts') || Gate::allows('viewTrashedPosts');
-        $query = $this->hasMany(Post::class);
+        $query = $this->hasMany(Post::class)->orderBy('created_at');
         return $withTrashed ? $query->withTrashed() : $query;
     }
 


### PR DESCRIPTION
For some reason, our database is not sending posts out in the order they were created.  Adding an orderBy('created_at') on the Thread->posts relation ensures they always come out in the expected order.