### PR TITLE
5.0: Improve behaviour of bulk DeleteThreads & RestoreThreads operations

### DIFF
--- a/src/Http/Controllers/Frontend/Bulk/ThreadController.php
+++ b/src/Http/Controllers/Frontend/Bulk/ThreadController.php
@@ -61,7 +61,7 @@ class ThreadController extends BaseController
     {
         $count = $request->fulfill();
 
-        return $this->bulkActionResponse($count, 'threads.updated');
+        return $this->bulkActionResponse($count, 'threads.deleted');
     }
 
     public function restore(RestoreThreads $request): RedirectResponse

--- a/views/category/show.blade.php
+++ b/views/category/show.blade.php
@@ -73,7 +73,6 @@
                                                 @can ('deleteThreads', $category)
                                                     <option value="delete">{{ trans('forum::general.delete') }}</option>
                                                     <option value="restore">{{ trans('forum::general.restore') }}</option>
-                                                    <option value="permadelete">{{ trans('forum::general.perma_delete') }}</option>
                                                 @endcan
                                                 @can ('moveThreadsFrom', $category)
                                                     <option value="move">{{ trans('forum::general.move') }}</option>
@@ -95,6 +94,15 @@
                                                 @include ('forum::category.partials.options', ['hide' => $category])
                                             </select>
                                         </div>
+
+                                        @if (config('forum.general.soft_deletes'))
+                                            <div class="form-check mb-3" v-if="selectedAction == 'delete'">
+                                                <input class="form-check-input" type="checkbox" name="permadelete" value="1" id="permadelete">
+                                                <label class="form-check-label" for="permadelete">
+                                                    {{ trans('forum::general.perma_delete') }}
+                                                </label>
+                                            </div>
+                                        @endif
 
                                         <div class="text-right">
                                             <button type="submit" class="btn btn-primary" @click="submit">{{ trans('forum::general.proceed') }}</button>


### PR DESCRIPTION
Updates the bulk DeleteThreads and RestoreThreads operations:

- Return early if no valid selection was made
- Reduce the number of queries executed per operation while still handling the edge case of selecting threads across multiple categories
- Avoid touching `updated_at` when doing the actual deletion/restoration
- Change the way categories are updated to be more robust