### PR TITLE
5.0: Improve behaviour of DeleteThread & RestoreThread

### DIFF
--- a/src/Http/Requests/BaseRequest.php
+++ b/src/Http/Requests/BaseRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace TeamTeaTime\Forum\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BaseRequest extends FormRequest
+{
+    private function isPermaDeleteRequested(): bool
+    {
+        return isset($this->validated()['permadelete']) && $this->validated()['permadelete'];
+    }
+
+    private function isPermaDeleting(): bool
+    {
+        return ! config('forum.general.soft_deletes') || $this->isPermaDeleteRequested();
+    }
+}

--- a/src/Http/Requests/Bulk/DestroyPosts.php
+++ b/src/Http/Requests/Bulk/DestroyPosts.php
@@ -3,12 +3,12 @@
 namespace TeamTeaTime\Forum\Http\Requests\Bulk;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Foundation\Http\FormRequest;
+use TeamTeaTime\Forum\Http\Requests\BaseRequest;
 use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Post;
 
-class DestroyPosts extends FormRequest implements FulfillableRequest
+class DestroyPosts extends BaseRequest implements FulfillableRequest
 {
     use AuthorizesAfterValidation;
 
@@ -35,7 +35,7 @@ class DestroyPosts extends FormRequest implements FulfillableRequest
     {
         $posts = $this->posts();
 
-        if (config('forum.general.soft_deletes') && isset($this->validated()['permadelete']) && $this->validated()['permadelete'] && method_exists(Post::class, 'forceDelete'))
+        if (config('forum.general.soft_deletes') && $this->isPermaDeleteRequested() && method_exists(Post::class, 'forceDelete'))
         {
             $post->forceDelete();
         }

--- a/src/Http/Requests/Bulk/DestroyThreads.php
+++ b/src/Http/Requests/Bulk/DestroyThreads.php
@@ -3,13 +3,13 @@
 namespace TeamTeaTime\Forum\Http\Requests\Bulk;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\DB;
+use TeamTeaTime\Forum\Http\Requests\BaseRequest;
 use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Thread;
 
-class DestroyThreads extends FormRequest implements FulfillableRequest
+class DestroyThreads extends BaseRequest implements FulfillableRequest
 {
     use AuthorizesAfterValidation;
 
@@ -68,11 +68,6 @@ class DestroyThreads extends FormRequest implements FulfillableRequest
         }
 
         return $rowsAffected;
-    }
-
-    private function isPermaDeleting(): bool
-    {
-        return ! config('forum.general.soft_deletes') || isset($this->validated()['permadelete']) && $this->validated()['permadelete'];
     }
 
     private function threads(): Builder

--- a/src/Http/Requests/Bulk/LockThreads.php
+++ b/src/Http/Requests/Bulk/LockThreads.php
@@ -2,11 +2,11 @@
 
 namespace TeamTeaTime\Forum\Http\Requests\Bulk;
 
-use Illuminate\Foundation\Http\FormRequest;
+use TeamTeaTime\Forum\Http\Requests\BaseRequest;
 use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 
-class LockThreads extends FormRequest implements FulfillableRequest
+class LockThreads extends BaseRequest implements FulfillableRequest
 {
     use AuthorizesAfterValidation;
 

--- a/src/Http/Requests/Bulk/MoveThreads.php
+++ b/src/Http/Requests/Bulk/MoveThreads.php
@@ -3,12 +3,12 @@
 namespace TeamTeaTime\Forum\Http\Requests\Bulk;
 
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Foundation\Http\FormRequest;
+use TeamTeaTime\Forum\Http\Requests\BaseRequest;
 use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Category;
 
-class MoveThreads extends FormRequest implements FulfillableRequest
+class MoveThreads extends BaseRequest implements FulfillableRequest
 {
     use AuthorizesAfterValidation;
 

--- a/src/Http/Requests/Bulk/PinThreads.php
+++ b/src/Http/Requests/Bulk/PinThreads.php
@@ -2,11 +2,11 @@
 
 namespace TeamTeaTime\Forum\Http\Requests\Bulk;
 
-use Illuminate\Foundation\Http\FormRequest;
+use TeamTeaTime\Forum\Http\Requests\BaseRequest;
 use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 
-class PinThreads extends FormRequest implements FulfillableRequest
+class PinThreads extends BaseRequest implements FulfillableRequest
 {
     use AuthorizesAfterValidation;
 

--- a/src/Http/Requests/Bulk/RestorePosts.php
+++ b/src/Http/Requests/Bulk/RestorePosts.php
@@ -2,11 +2,11 @@
 
 namespace TeamTeaTime\Forum\Http\Requests\Bulk;
 
-use Illuminate\Foundation\Http\FormRequest;
+use TeamTeaTime\Forum\Http\Requests\BaseRequest;
 use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 
-class RestorePosts extends FormRequest implements FulfillableRequest
+class RestorePosts extends BaseRequest implements FulfillableRequest
 {
     use AuthorizesAfterValidation;
 

--- a/src/Http/Requests/Bulk/RestoreThreads.php
+++ b/src/Http/Requests/Bulk/RestoreThreads.php
@@ -3,14 +3,14 @@
 namespace TeamTeaTime\Forum\Http\Requests\Bulk;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\DB;
+use TeamTeaTime\Forum\Http\Requests\BaseRequest;
 use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Thread;
 use TeamTeaTime\Forum\Support\Stats;
 
-class RestoreThreads extends FormRequest implements FulfillableRequest
+class RestoreThreads extends BaseRequest implements FulfillableRequest
 {
     use AuthorizesAfterValidation;
 

--- a/src/Http/Requests/DestroyCategory.php
+++ b/src/Http/Requests/DestroyCategory.php
@@ -2,11 +2,10 @@
 
 namespace TeamTeaTime\Forum\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Category;
 
-class DestroyCategory extends FormRequest implements FulfillableRequest
+class DestroyCategory extends BaseRequest implements FulfillableRequest
 {
     public function authorize(Category $category): bool
     {

--- a/src/Http/Requests/DestroyPost.php
+++ b/src/Http/Requests/DestroyPost.php
@@ -2,11 +2,10 @@
 
 namespace TeamTeaTime\Forum\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Post;
 
-class DestroyPost extends FormRequest implements FulfillableRequest
+class DestroyPost extends BaseRequest implements FulfillableRequest
 {
     public function authorize(): bool
     {
@@ -25,7 +24,7 @@ class DestroyPost extends FormRequest implements FulfillableRequest
     {
         $post = $this->route('post');
 
-        if (config('forum.general.soft_deletes') && isset($this->validated()['permadelete']) && $this->validated()['permadelete'] && method_exists($post, 'forceDelete'))
+        if (config('forum.general.soft_deletes') && $this->isPermaDeleteRequested && is_callable([$post, 'forceDelete']))
         {
             $post->forceDelete();
         }

--- a/src/Http/Requests/DestroyThread.php
+++ b/src/Http/Requests/DestroyThread.php
@@ -2,12 +2,11 @@
 
 namespace TeamTeaTime\Forum\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\DB;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Thread;
 
-class DestroyThread extends FormRequest implements FulfillableRequest
+class DestroyThread extends BaseRequest implements FulfillableRequest
 {
     public function authorize(): bool
     {
@@ -61,10 +60,5 @@ class DestroyThread extends FormRequest implements FulfillableRequest
         }
 
         return $thread;
-    }
-
-    private function isPermaDeleting(): bool
-    {
-        return ! config('forum.general.soft_deletes') || isset($this->validated()['permadelete']) && $this->validated()['permadelete'];
     }
 }

--- a/src/Http/Requests/LockThread.php
+++ b/src/Http/Requests/LockThread.php
@@ -2,10 +2,9 @@
 
 namespace TeamTeaTime\Forum\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 
-class LockThread extends FormRequest implements FulfillableRequest
+class LockThread extends BaseRequest implements FulfillableRequest
 {
     public function authorize(): bool
     {

--- a/src/Http/Requests/MarkThreadsRead.php
+++ b/src/Http/Requests/MarkThreadsRead.php
@@ -2,12 +2,11 @@
 
 namespace TeamTeaTime\Forum\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
 use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Thread;
 
-class MarkThreadsRead extends FormRequest implements FulfillableRequest
+class MarkThreadsRead extends BaseRequest implements FulfillableRequest
 {
     public function authorize(): bool
     {

--- a/src/Http/Requests/MoveThread.php
+++ b/src/Http/Requests/MoveThread.php
@@ -2,12 +2,10 @@
 
 namespace TeamTeaTime\Forum\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
-
 use TeamTeaTime\Forum\Models\Category;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 
-class MoveThread extends FormRequest implements FulfillableRequest
+class MoveThread extends BaseRequest implements FulfillableRequest
 {
     public function authorize(): bool
     {

--- a/src/Http/Requests/PinThread.php
+++ b/src/Http/Requests/PinThread.php
@@ -2,10 +2,9 @@
 
 namespace TeamTeaTime\Forum\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 
-class PinThread extends FormRequest implements FulfillableRequest
+class PinThread extends BaseRequest implements FulfillableRequest
 {
     public function authorize(): bool
     {

--- a/src/Http/Requests/RenameThread.php
+++ b/src/Http/Requests/RenameThread.php
@@ -2,10 +2,9 @@
 
 namespace TeamTeaTime\Forum\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 
-class RenameThread extends FormRequest implements FulfillableRequest
+class RenameThread extends BaseRequest implements FulfillableRequest
 {
     public function authorize(): bool
     {

--- a/src/Http/Requests/RestorePost.php
+++ b/src/Http/Requests/RestorePost.php
@@ -2,10 +2,9 @@
 
 namespace TeamTeaTime\Forum\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 
-class RestorePost extends FormRequest implements FulfillableRequest
+class RestorePost extends BaseRequest implements FulfillableRequest
 {
     public function authorize(): bool
     {

--- a/src/Http/Requests/RestoreThread.php
+++ b/src/Http/Requests/RestoreThread.php
@@ -3,6 +3,7 @@
 namespace TeamTeaTime\Forum\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\DB;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 
 class RestoreThread extends FormRequest implements FulfillableRequest
@@ -22,6 +23,14 @@ class RestoreThread extends FormRequest implements FulfillableRequest
     {
         $thread = $this->route('thread');
         $thread->restoreWithoutTouch();
+
+        $category = $thread->category;
+        $category->update([
+            'newest_thread_id' => max($thread->id, $category->newest_thread_id),
+            'latest_active_thread_id' => $category->getLatestActiveThreadId(),
+            'thread_count' => DB::raw("thread_count + 1"),
+            'post_count' => DB::raw("post_count + {$thread->postCount}")
+        ]);
 
         return $thread;
     }

--- a/src/Http/Requests/RestoreThread.php
+++ b/src/Http/Requests/RestoreThread.php
@@ -2,11 +2,10 @@
 
 namespace TeamTeaTime\Forum\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\DB;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 
-class RestoreThread extends FormRequest implements FulfillableRequest
+class RestoreThread extends BaseRequest implements FulfillableRequest
 {
     public function authorize(): bool
     {

--- a/src/Http/Requests/StoreCategory.php
+++ b/src/Http/Requests/StoreCategory.php
@@ -2,11 +2,10 @@
 
 namespace TeamTeaTime\Forum\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Category;
 
-class StoreCategory extends FormRequest implements FulfillableRequest
+class StoreCategory extends BaseRequest implements FulfillableRequest
 {
     public function authorize(): bool
     {

--- a/src/Http/Requests/StorePost.php
+++ b/src/Http/Requests/StorePost.php
@@ -2,13 +2,12 @@
 
 namespace TeamTeaTime\Forum\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Category;
 use TeamTeaTime\Forum\Models\Post;
 use TeamTeaTime\Forum\Models\Thread;
 
-class StorePost extends FormRequest implements FulfillableRequest
+class StorePost extends BaseRequest implements FulfillableRequest
 {
     public function authorize(Thread $thread): bool
     {

--- a/src/Http/Requests/StoreThread.php
+++ b/src/Http/Requests/StoreThread.php
@@ -2,12 +2,11 @@
 
 namespace TeamTeaTime\Forum\Http\Requests;
 
-use Illuminate\Foundation\Http\FormRequest;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Category;
 use TeamTeaTime\Forum\Models\Thread;
 
-class StoreThread extends FormRequest implements FulfillableRequest
+class StoreThread extends BaseRequest implements FulfillableRequest
 {
     public function authorize(Category $category): bool
     {

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -79,6 +79,20 @@ abstract class BaseModel extends Model
         $this->timestamps = true;
     }
 
+    public function deleteWithoutTouch()
+    {
+        $this->timestamps = false;
+        $this->delete();
+        $this->timestamps = true;
+    }
+
+    public function forceDeleteWithoutTouch()
+    {
+        $this->timestamps = false;
+        $this->forceDelete();
+        $this->timestamps = true;
+    }
+
     public function restoreWithoutTouch()
     {
         $this->timestamps = false;

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -74,29 +74,30 @@ abstract class BaseModel extends Model
 
     public function saveWithoutTouch()
     {
-        $this->timestamps = false;
-        $this->save();
-        $this->timestamps = true;
+        $this->withoutTouch('save');
     }
 
     public function deleteWithoutTouch()
     {
-        $this->timestamps = false;
-        $this->delete();
-        $this->timestamps = true;
+        $this->withoutTouch('delete');
     }
 
     public function forceDeleteWithoutTouch()
     {
-        $this->timestamps = false;
-        $this->forceDelete();
-        $this->timestamps = true;
+        $this->withoutTouch('forceDelete');
     }
 
     public function restoreWithoutTouch()
     {
+        $this->withoutTouch('restore');
+    }
+
+    protected function withoutTouch(string $method)
+    {
+        if (! is_callable([$this, $method])) throw new \Exception("Method '{$method}' is not callable.");
+
         $this->timestamps = false;
-        $this->restore();
+        $this->{$method}();
         $this->timestamps = true;
     }
 }

--- a/src/Models/Observers/ThreadObserver.php
+++ b/src/Models/Observers/ThreadObserver.php
@@ -29,23 +29,4 @@ class ThreadObserver
             $newCategory->save();
         }
     }
-
-    public function deleted($thread)
-    {
-        if (! $thread->deleted_at || $thread->deleted_at->toDateTimeString() !== Carbon::now()->toDateTimeString())
-        {
-            // The thread was force-deleted, so the posts should be too
-            $thread->posts()->withTrashed()->forceDelete();
-
-            $thread->readers()->detach();
-        }
-
-        Stats::syncForCategory($thread->category);
-    }
-
-    public function restored($thread)
-    {
-        Stats::syncForThread($thread);
-        Stats::syncForCategory($thread->category);
-    }
 }

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -94,6 +94,11 @@ class Thread extends BaseModel
         return ($this->updatedSince($this->reader)) ? trans('forum::general.' . self::STATUS_UPDATED) : null;
     }
 
+    public function getPostCountAttribute(): int
+    {
+        return $this->reply_count + 1;
+    }
+
     public function getLastPost(): Post
     {
         return $this->posts()->orderBy('created_at', 'desc')->first();

--- a/translations/de/threads.php
+++ b/translations/de/threads.php
@@ -13,6 +13,7 @@ return [
     'new_updated' => "Neue & geänderte Themen",
     'newest' => "Neuestes Thema",
     'none_found' => "Keine Themen gefunden",
+    'perma_delete' => "Permanently delete thread|Permanently delete threads",
     'perma_deleted' => "Thema entgültig gelöscht|Themen entgültig gelöscht",
     'pin' => "Anheften",
     'pinned' => "Angeheftet",

--- a/translations/en/threads.php
+++ b/translations/en/threads.php
@@ -12,6 +12,7 @@ return [
     'new_thread' => "New thread",
     'newest' => "Newest thread",
     'none_found' => "No threads found",
+    'perma_delete' => "Permanently delete thread|Permanently delete threads",
     'perma_deleted' => "Thread permanently deleted|Threads permanently deleted",
     'pin' => "Pin",
     'pinned' => "Pinned",

--- a/translations/es/threads.php
+++ b/translations/es/threads.php
@@ -13,6 +13,7 @@ return [
     'new_updated' => "Discusiones nuevas y actualizadas",
     'newest' => "Discusiones nuevas",
     'none_found' => "No se encontraron discusiones",
+    'perma_delete' => "Permanently delete thread|Permanently delete threads",
     'perma_deleted' => "Discusión eliminará de forma permanente|Discusiones eliminarán de forma permanente",
     'post_the_first' => "Crea la priméra!",
     'pin' => "Sujetar",

--- a/translations/fr/threads.php
+++ b/translations/fr/threads.php
@@ -13,6 +13,7 @@ return [
     'new_updated' => "Nouvelles et mises à jour les discussions",
     'newest' => "Sujet récent",
     'none_found' => "Aucun sujet trouvé",
+    'perma_delete' => "Permanently delete thread|Permanently delete threads",
     'perma_deleted' => "Sujet définitivement supprimé|Sujets définitivement supprimés",
     'pin' => "Épingler",
     'pinned' => "Épinglé",

--- a/translations/it/threads.php
+++ b/translations/it/threads.php
@@ -13,6 +13,7 @@ return [
     'new_updated' => "Discussioni nuove ed aggiornate",
     'newest' => "Discussione più recente",
     'none_found' => "Nessuna discussione trovata",
+    'perma_delete' => "Permanently delete thread|Permanently delete threads",
     'perma_deleted' => "Discussione eliminata in modo permanente|Discussioni eliminate definitivamente",
     'pin' => "Importante",
     'pinned' => "Resa importante",

--- a/translations/nl/threads.php
+++ b/translations/nl/threads.php
@@ -13,6 +13,7 @@ return [
     'new_updated' => "Nieuwe & geüpdate onderwerpen",
     'newest' => "Nieuwste onderwerp",
     'none_found' => "Geen onderwerpen gevonden",
+    'perma_delete' => "Permanently delete thread|Permanently delete threads",
     'perma_deleted' => "Onderwerp permanent verwijderd|Onderwerpen permanent verwijderd",
     'pin' => "Vastpinnen",
     'pinned' => "Vastgepind",

--- a/translations/pt-br/threads.php
+++ b/translations/pt-br/threads.php
@@ -13,6 +13,7 @@ return [
     'new_updated' => "Tópico novo e atualizado",
     'newest' => "Novos tópicos",
     'none_found' => "Nenhum tópico encontrado",
+    'perma_delete' => "Permanently delete thread|Permanently delete threads",
     'perma_deleted' => "Tópico permanentemente deletado|Tópicos permanentementes deletados",
     'pin' => "Destaque",
     'pinned' => "Destacado",

--- a/translations/ro/threads.php
+++ b/translations/ro/threads.php
@@ -13,6 +13,7 @@ return [
     'new_updated' => "Discuții noi și actualizate",
     'newest' => "Cea mai nouă discuție",
     'none_found' => "Nicio discuție găsită",
+    'perma_delete' => "Permanently delete thread|Permanently delete threads",
     'perma_deleted' => "Discuție șters definitiv|Discuții șters definitiv",
     'pin' => "Fixa",
     'pinned' => "Fixate",

--- a/translations/ru/threads.php
+++ b/translations/ru/threads.php
@@ -13,6 +13,7 @@ return [
     'new_updated' => "Новые и обновленные ветки",
     'newest' => "Новейшая ветка",
     'none_found' => "Нет веток",
+    'perma_delete' => "Permanently delete thread|Permanently delete threads",
     'perma_deleted' => "Тема удалена навсегда|Темы удалены навсегда",
     'pin' => "Закрепить",
     'pinned' => "Закреплено",

--- a/translations/sr/threads.php
+++ b/translations/sr/threads.php
@@ -13,6 +13,7 @@ return [
     'new_updated' => "Nove i izmenjene teme",
     'newest' => "Najnovija tema",
     'none_found' => "Teme nisu nadđene",
+    'perma_delete' => "Permanently delete thread|Permanently delete threads",
     'perma_deleted' => "Tema trajno izbrisana|Teme trajno izbrisane",
     'pin' => "Zakači",
     'pinned' => "Zakačeno",

--- a/translations/sv/threads.php
+++ b/translations/sv/threads.php
@@ -13,6 +13,7 @@ return [
     'new_updated' => "Nya & uppdaterade trådar",
     'newest' => "Senaste tråden",
     'none_found' => "Inga trådar hittades",
+    'perma_delete' => "Permanently delete thread|Permanently delete threads",
     'perma_deleted' => "Tråd bort permanent|Ämnen bort permanent",
     'pin' => "Pin",
     'pinned' => "Pinnad",

--- a/translations/th/threads.php
+++ b/translations/th/threads.php
@@ -13,6 +13,7 @@ return [
     'new_updated' => 'เพิ่ม และบันทึกหัวข้อใหม่แล้ว',
     'newest' => 'หัวข้อใหม่สุด',
     'none_found' => 'ไม่มีหัวข้อที่กำลังค้นหา',
+    'perma_delete' => "Permanently delete thread|Permanently delete threads",
     'perma_deleted' => 'หัวข้อจะถูกลบถาวร|หัวข้อจะถูกลบถาวร',
     'pin' => 'ปักหมุด',
     'pinned' => 'ปักหมุด',

--- a/translations/tr/threads.php
+++ b/translations/tr/threads.php
@@ -13,6 +13,7 @@ return [
     'new_updated' => "Yeni & güncellenen konular",
     'newest' => "Son Konular",
     'none_found' => "Konu bulunamadı",
+    'perma_delete' => "Permanently delete thread|Permanently delete threads",
     'perma_deleted' => "Konu kalıcı olarak silindi|Konular kalıcı olarak silindi",
     'pin' => "Sabitle",
     'pinned' => "Sabitlendi",

--- a/views/post/partials/list.blade.php
+++ b/views/post/partials/list.blade.php
@@ -1,5 +1,5 @@
 <div id="post-{{ $post->sequence }}"
-    class="post card mb-2 {{ $post->trashed() ? 'deleted' : '' }}"
+    class="post card mb-2 {{ $post->trashed() || $thread->trashed() ? 'deleted' : '' }}"
     :class="{ 'border-primary': selectedPosts.includes({{ $post->id }}) }">
     <div class="card-header">
         @if (! isset($single) || ! $single)
@@ -27,7 +27,7 @@
             @include ('forum::post.partials.quote', ['post' => $post->parent])
         @endif
 
-        @if ($post->trashed())
+        @if ($post->trashed() || $thread->trashed())
             @can ('viewTrashedPosts')
                 {!! Forum::render($post->content) !!}
                 <br>

--- a/views/thread/show.blade.php
+++ b/views/thread/show.blade.php
@@ -7,17 +7,18 @@
             
             <div>
                 @if (Gate::allows('delete', $thread) || Gate::allows('restore', $thread))
-                    <div class="btn-group" role="group">
-                        @if ($thread->trashed() && Gate::allows('restore', $thread))
-                            <a href="#" class="btn btn-secondary" data-open-modal="restore-thread">
-                                <i data-feather="refresh-cw"></i> {{ trans('forum::general.restore') }}
-                            </a>
-                        @elseif (Gate::allows('delete', $thread))
-                            <a href="#" class="btn btn-danger mr-3" data-open-modal="delete-thread">
-                                <i data-feather="trash"></i> {{ trans('forum::general.delete') }}
-                            </a>
-                        @endif
-                    </div>
+                    @if ($thread->trashed() && Gate::allows('restore', $thread))
+                        <a href="#" class="btn btn-danger mr-3" data-open-modal="perma-delete-thread">
+                            <i data-feather="trash"></i> {{ trans('forum::general.perma_delete') }}
+                        </a>
+                        <a href="#" class="btn btn-secondary" data-open-modal="restore-thread">
+                            <i data-feather="refresh-cw"></i> {{ trans('forum::general.restore') }}
+                        </a>
+                    @elseif (Gate::allows('delete', $thread))
+                        <a href="#" class="btn btn-danger mr-3" data-open-modal="delete-thread">
+                            <i data-feather="trash"></i> {{ trans('forum::general.delete') }}
+                        </a>
+                    @endif
                 @endif
 
                 @can ('manageThreads', $category)
@@ -208,6 +209,23 @@
                     <button type="submit" class="btn btn-danger">{{ trans('forum::general.proceed') }}</button>
                 @endslot
             @endcomponent
+
+            @if (config('forum.general.soft_deletes'))
+                @component('forum::modal-form')
+                    @slot('key', 'perma-delete-thread')
+                    @slot('title', '<i data-feather="trash" class="text-muted"></i>' . trans_choice('forum::threads.perma_delete', 1))
+                    @slot('route', Forum::route('thread.delete', $thread))
+                    @slot('method', 'DELETE')
+
+                    <input type="hidden" name="permadelete" value="1" />
+
+                    {{ trans('forum::general.generic_confirm') }}
+
+                    @slot('actions')
+                        <button type="submit" class="btn btn-danger">{{ trans('forum::general.proceed') }}</button>
+                    @endslot
+                @endcomponent
+            @endif
         @endcan
 
         @if (! $thread->trashed())


### PR DESCRIPTION
This PR does the following:

- Drops the `deleted` and `restored` handlers in ThreadObserver in favour of reconciling category stats and FKs in the DeleteThread and RestoreThread requests
- Changes the post view so that in soft-deleted threads, posts appear as if they have been soft-deleted too
- Changes thread actions in the frontend to include a "Permanently delete" button when the thread is already soft-deleted so that restoring first is no longer necessary
