### PR TITLE
5.0: Fix/improve bulk request operations

### DIFF
--- a/src/Events/UserBulkMovedThreads.php
+++ b/src/Events/UserBulkMovedThreads.php
@@ -8,12 +8,14 @@ use TeamTeaTime\Forum\Models\Category;
 
 class UserBulkMovedThreads extends CollectionEvent
 {
+    public Collection $sourceCategories;
     public Category $destinationCategory;
 
-    public function __construct($user, Collection $threads, Category $destinationCategory)
+    public function __construct($user, Collection $threads, Collection $sourceCategories, Category $destinationCategory)
     {
         parent::__construct($user, $threads);
 
+        $this->sourceCategories = $sourceCategories;
         $this->destinationCategory = $destinationCategory;
     }
 }

--- a/src/Http/Requests/Bulk/DestroyPosts.php
+++ b/src/Http/Requests/Bulk/DestroyPosts.php
@@ -39,15 +39,9 @@ class DestroyPosts extends BaseRequest implements FulfillableRequest
     {
         $posts = $this->postsAsModels()->get();
 
-        $rowsAffected = 0;
-        if ($this->isPermaDeleting())
-        {
-            $rowsAffected = $this->posts()->delete();
-        }
-        else
-        {
-            $rowsAffected = $this->posts()->whereNull('deleted_at')->update(['deleted_at' => DB::raw('now()')]);
-        }
+        $rowsAffected = $this->isPermaDeleting()
+            ? $this->posts()->delete()
+            : $this->posts()->whereNull('deleted_at')->update(['deleted_at' => DB::raw('now()')]);
 
         if ($rowsAffected == 0) return collect();
 

--- a/src/Http/Requests/Bulk/DestroyPosts.php
+++ b/src/Http/Requests/Bulk/DestroyPosts.php
@@ -2,8 +2,10 @@
 
 namespace TeamTeaTime\Forum\Http\Requests\Bulk;
 
-use Illuminate\Database\Query\Builder;
-use TeamTeaTime\Forum\Events\UserBulkDestroyedPosts;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\DB;
+use TeamTeaTime\Forum\Events\UserBulkDeletedPosts;
 use TeamTeaTime\Forum\Http\Requests\BaseRequest;
 use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
@@ -23,7 +25,8 @@ class DestroyPosts extends BaseRequest implements FulfillableRequest
 
     public function authorizeValidated(): bool
     {
-        $posts = $this->posts()->get();
+        $posts = $this->postsAsModels()->get();
+
         foreach ($posts as $post)
         {
             if (! $this->user()->can('delete', $post)) return false;
@@ -34,42 +37,81 @@ class DestroyPosts extends BaseRequest implements FulfillableRequest
 
     public function fulfill()
     {
-        $posts = $this->posts();
+        $posts = $this->postsAsModels()->get();
 
-        if (config('forum.general.soft_deletes') && $this->isPermaDeleteRequested() && method_exists(Post::class, 'forceDelete'))
+        $rowsAffected = 0;
+        if ($this->isPermaDeleting())
         {
-            foreach ($posts as $post)
-            {
-                $post->forceDelete();
-            }
+            $rowsAffected = $this->posts()->delete();
         }
         else
         {
-            foreach ($posts as $post)
-            {
-                $post->delete();
-            }
+            $rowsAffected = $this->posts()->whereNull('deleted_at')->update(['deleted_at' => DB::raw('now()')]);
         }
+
+        if ($rowsAffected == 0) return collect();
 
         event(new UserBulkDeletedPosts($this->user(), $posts));
-        
-        $postsByThread = $posts->select('thread_id')->distinct()->get();
-        foreach ($postsByThread as $post)
+
+        $threads = $posts->pluck('thread')->unique();
+        $categories = $threads->pluck('category')->unique();
+
+        foreach ($threads as $thread)
         {
-            $post->thread->syncLastPost();
-            $post->thread->category->syncLatestActiveThread();
+            // @TODO: handle deletion of thread if no posts remain
+
+            $removedPostCount = $posts->where('thread_id', $thread->id)->whereNull('deleted_at')->count();
+
+            // Skip updates if the affected posts were already soft-deleted
+            if ($removedPostCount == 0) continue;
+
+            $thread->updateWithoutTouch([
+                'last_post_id' => $thread->getLastPost()->id,
+                'reply_count' => DB::raw("reply_count - {$removedPostCount}")
+            ]);
+
+            $thread->posts->each(function ($p)
+            {
+                $p->updateWithoutTouch(['sequence' => $p->getSequenceNumber()]);
+            });
         }
 
-        return $posts->get();
+        foreach ($categories as $category)
+        {
+            $categoryThreadIds = $threads->where('category_id', $category->id)->pluck('id');
+            $removedPostCount = $posts->whereIn('thread_id', $categoryThreadIds)->whereNull('deleted_at')->count();
+
+            // Skip updates if the affected posts were already soft-deleted
+            if ($removedPostCount == 0) continue;
+
+            $category->updateWithoutTouch([
+                'latest_active_thread' => $category->getLatestActiveThreadId(),
+                'post_count' => DB::raw("post_count - {$removedPostCount}")
+            ]);
+        }
+
+        return $posts;
     }
 
-    private function posts(): Builder
+    private function posts(): QueryBuilder
     {
-        $query = \DB::table(Post::getTableName());
+        $query = DB::table(Post::getTableName());
 
         if (! $this->user()->can('viewTrashedPosts'))
         {
             $query = $query->whereNull('deleted_at');
+        }
+
+        return $query->whereIn('id', $this->validated()['posts']);
+    }
+
+    private function postsAsModels(): EloquentBuilder
+    {
+        $query = Post::query();
+
+        if ($this->user()->can('viewTrashedPosts'))
+        {
+            $query = $query->withTrashed();
         }
 
         return $query->whereIn('id', $this->validated()['posts']);

--- a/src/Http/Requests/Bulk/RestoreThreads.php
+++ b/src/Http/Requests/Bulk/RestoreThreads.php
@@ -42,13 +42,13 @@ class RestoreThreads extends BaseRequest implements FulfillableRequest
         if ($threads->count() === 0) return 0;
 
         $threadsByCategory = $threads->groupBy('category_id');
-        foreach ($threadsByCategory as $categoryId => $threads)
+        foreach ($threadsByCategory as $threads)
         {
             $threadCount = $threads->count();
             $postCount = $threads->sum('reply_count') + $threadCount; // count the first post of each thread
             $category = $threads->first()->category;
 
-            $category->update([
+            $category->updateWithoutTouch([
                 'newest_thread_id' => max($threads->max('id'), $category->newest_thread_id),
                 'latest_active_thread_id' => $category->getLatestActiveThreadId(),
                 'thread_count' => DB::raw("thread_count + {$threadCount}"),

--- a/src/Http/Requests/DestroyPost.php
+++ b/src/Http/Requests/DestroyPost.php
@@ -57,8 +57,7 @@ class DestroyPost extends BaseRequest implements FulfillableRequest
         // Update sequence numbers for all of the thread's posts
         $post->thread->posts->each(function ($p)
         {
-            $p->sequence = $p->getSequenceNumber();
-            $p->saveWithoutTouch();
+            $p->updateWithoutTouch(['sequence' => $p->getSequenceNumber()]);
         });
 
         event(new UserDeletedPost($this->user(), $post));

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -81,22 +81,4 @@ class Category extends BaseModel
         $thread = $this->threads()->orderBy('updated_at', 'desc')->first();
         return $thread ? $thread->id : null;
     }
-
-    public function syncNewestThread(): bool
-    {
-        return $this->update(['newest_thread_id' => $this->getNewestThreadId()]);
-    }
-
-    public function syncLatestActiveThread(): bool
-    {
-        return $this->update(['latest_active_thread_id' => $this->getLatestActiveThreadId()]);
-    }
-
-    public function syncCurrentThreads(): bool
-    {
-        return $this->update([
-            'newest_thread_id' => $this->getNewestThreadId(),
-            'latest_active_thread_id' => $this->getLatestActiveThreadId()
-        ]);
-    }
 }

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -117,9 +117,4 @@ class Thread extends BaseModel
             $this->reader->touch();
         }
     }
-
-    public function syncLastPost(): bool
-    {
-        return $this->update(['last_post_id' => $this->getLastPost()->id]);
-    }
 }


### PR DESCRIPTION
**Depends on #231**

This PR updates bulk requests to fix and improve several things:

- Ensures foreign keys and stat columns on threads and categories are correctly updated
- Uses the Eloquent or raw query builder depending on needs (in some cases we need to work with actual model instances, in others we need to forego Eloquent's timestamp touching behaviour, etc)
- Reduces queries by consolidating updates and working with existing collections where possible
- Removes the no longer used `sync*` model methods