### PR TITLE
5.0: Ensure category content is removed upon deletion

### DIFF
--- a/src/Actions/DeleteCategory.php
+++ b/src/Actions/DeleteCategory.php
@@ -2,7 +2,10 @@
 
 namespace TeamTeaTime\Forum\Actions;
 
+use Illuminate\Support\Facades\DB;
 use TeamTeaTime\Forum\Models\Category;
+use TeamTeaTime\Forum\Models\Post;
+use TeamTeaTime\Forum\Models\Thread;
 
 class DeleteCategory extends BaseAction
 {
@@ -15,6 +18,22 @@ class DeleteCategory extends BaseAction
 
     protected function transact()
     {
-        return $this->category->delete();
+        $categoryIdsToDelete = [];
+        $threadIdsToDelete = [];
+        if (! $this->category->isEmpty())
+        {
+            $descendantIds = $this->category->descendants->pluck('id')->toArray();
+            $categoryIdsToDelete = $descendantIds;
+            $threadIdsToDelete = Thread::whereIn('category_id', $descendantIds)->withTrashed()->pluck('id')->toArray();
+        }
+
+        $categoryIdsToDelete[] = $this->category->id;
+        $threadIdsToDelete = array_merge($threadIdsToDelete, $this->category->threads()->withTrashed()->pluck('id')->toArray());
+
+        Post::whereIn('thread_id', $threadIdsToDelete)->withTrashed()->forceDelete();
+        DB::table(Thread::READERS_TABLE)->whereIn('thread_id', $threadIdsToDelete)->delete();
+        Thread::whereIn('id', $threadIdsToDelete)->withTrashed()->forceDelete();
+
+        return Category::whereIn('id', $categoryIdsToDelete)->delete();
     }
 }

--- a/src/Events/UserBulkManagedCategories.php
+++ b/src/Events/UserBulkManagedCategories.php
@@ -7,11 +7,13 @@ class UserBulkManagedCategories
     /** @var mixed */
     public $user;
 
-    public array $categories;
+    public int $categoriesAffected;
+    public array $categoryData;
 
-    public function __construct($user, array $categories)
+    public function __construct($user, int $categoriesAffected, array $categoryData)
     {
         $this->user = $user;
-        $this->categories = $categories;
+        $this->categoriesAffected = $categoriesAffected;
+        $this->categoryData = $categoryData;
     }
 }

--- a/src/Http/Controllers/Web/CategoryController.php
+++ b/src/Http/Controllers/Web/CategoryController.php
@@ -71,7 +71,7 @@ class CategoryController extends BaseController
 
         Forum::alert('success', 'categories.deleted', 1);
 
-        return redirect(config('forum.routing.prefix'));
+        return redirect(Forum::route('index'));
     }
 
     public function manage(Request $request): View

--- a/src/Http/Requests/Bulk/ManageCategories.php
+++ b/src/Http/Requests/Bulk/ManageCategories.php
@@ -24,11 +24,12 @@ class ManageCategories extends FormRequest implements FulfillableRequest
 
     public function fulfill()
     {
-        $action = new Action($this->validated()['categories']);
-        $categories = $action->execute();
+        $categoryData = $this->validated()['categories'];
+        $action = new Action($categoryData);
+        $categoriesAffected = $action->execute();
 
-        event(new UserBulkManagedCategories($this->user(), $categories));
+        event(new UserBulkManagedCategories($this->user(), $categoriesAffected, $categoryData));
 
-        return $categories;
+        return $categoriesAffected;
     }
 }

--- a/src/Http/Requests/CreateCategory.php
+++ b/src/Http/Requests/CreateCategory.php
@@ -31,10 +31,10 @@ class CreateCategory extends FormRequest implements FulfillableRequest
 
         $action = new Action(
             $input['title'],
-            $input['description'],
+            isset($input['description']) ? $input['description'] : "",
             $input['color'],
-            $input['accepts_threads'],
-            $input['is_private']
+            isset($input['accepts_threads']) && $input['accepts_threads'],
+            isset($input['is_private']) && $input['is_private']
         );
 
         $category = $action->execute();

--- a/src/Http/Requests/DeleteCategory.php
+++ b/src/Http/Requests/DeleteCategory.php
@@ -6,14 +6,29 @@ use Illuminate\Foundation\Http\FormRequest;
 use TeamTeaTime\Forum\Actions\DeleteCategory as Action;
 use TeamTeaTime\Forum\Events\UserDeletedCategory;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
+use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Http\Requests\Traits\HandlesDeletion;
 use TeamTeaTime\Forum\Models\Category;
 
 class DeleteCategory extends FormRequest implements FulfillableRequest
 {
-    use HandlesDeletion;
+    use AuthorizesAfterValidation, HandlesDeletion;
 
-    public function authorize(): bool
+    public function rules(): array
+    {
+        return [
+            'force' => ['boolean']
+        ];
+    }
+
+    public function withValidator($validator)
+    {
+        $validator->sometimes('force', 'required', function ($input) {
+            return ! $this->route('category')->isEmpty();
+        });
+    }
+
+    public function authorizeValidated(): bool
     {
         return $this->user()->can('delete', $this->route('category'));
     }

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -81,4 +81,9 @@ class Category extends BaseModel
         $thread = $this->threads()->orderBy('updated_at', 'desc')->first();
         return $thread ? $thread->id : null;
     }
+
+    public function isEmpty(): bool
+    {
+        return $this->descendants->count() == 0 && $this->threads()->withTrashed()->count() == 0;
+    }
 }

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -23,6 +23,8 @@ class Thread extends BaseModel
     protected $dates = ['deleted_at'];
     protected $fillable = ['category_id', 'author_id', 'title', 'locked', 'pinned', 'reply_count', 'first_post_id', 'last_post_id', 'updated_at'];
 
+    const READERS_TABLE = 'forum_threads_read';
+
     const STATUS_UNREAD = 'unread';
     const STATUS_UPDATED = 'updated';
 
@@ -41,7 +43,7 @@ class Thread extends BaseModel
     {
         return $this->belongsToMany(
             config('forum.integration.user_model'),
-            'forum_threads_read',
+            self::READERS_TABLE,
             'thread_id',
             'user_id'
         )->withTimestamps();

--- a/translations/de/categories.php
+++ b/translations/de/categories.php
@@ -4,6 +4,7 @@ return [
 
     'actions' => "Kategorie-Aktionen",
     'category' => "Kategorie|Kategorien",
+    'confirm_nonempty_delete' => "Yes, I want to permanently delete this category and everything inside it",
     'create' => "Kategorie anlegen",
     'created' => "Kategorie angelegt",
     'deleted' => "Kategorie gelöscht|Kategorien gelöscht",

--- a/translations/en/categories.php
+++ b/translations/en/categories.php
@@ -4,6 +4,7 @@ return [
 
     'actions' => "Category actions",
     'category' => "Category|Categories",
+    'confirm_nonempty_delete' => "Yes, I want to permanently delete this category and everything inside it",
     'create' => "Create category",
     'created' => "Category created",
     'deleted' => "Category deleted|Categories deleted",

--- a/translations/es/categories.php
+++ b/translations/es/categories.php
@@ -4,6 +4,7 @@ return [
 
     'actions' => "Acciones categoría",
     'category' => "Categoría|Categorías",
+    'confirm_nonempty_delete' => "Yes, I want to permanently delete this category and everything inside it",
     'create' => "Crear categoría",
     'created' => "Categoría creado|Categorías creado",
     'deleted' => "Categoría eliminada|Categorías eliminada",

--- a/translations/fr/categories.php
+++ b/translations/fr/categories.php
@@ -4,6 +4,7 @@ return [
 
     'actions' => "Catégorie actions",
     'category' => "Catégorie|Catégories",
+    'confirm_nonempty_delete' => "Yes, I want to permanently delete this category and everything inside it",
     'create' => "Créer catégorie",
     'created' => "Catégorie créé|Catégories créé",
     'deleted' => "Catégorie supprimé|Catégories supprimés",

--- a/translations/it/categories.php
+++ b/translations/it/categories.php
@@ -4,6 +4,7 @@ return [
 
     'actions' => "Azioni categoria",
     'category' => "Categoria|Categorie",
+    'confirm_nonempty_delete' => "Yes, I want to permanently delete this category and everything inside it",
     'create' => "Crea categoria",
     'created' => "Categoria creata",
     'deleted' => "Categoria eliminata|Categorie eliminate",

--- a/translations/nl/categories.php
+++ b/translations/nl/categories.php
@@ -4,6 +4,7 @@ return [
 
     'actions' => "Categorie acties",
     'category' => "Categorie|Categorieën",
+    'confirm_nonempty_delete' => "Yes, I want to permanently delete this category and everything inside it",
     'create' => "Categorie maken",
     'created' => "Categorie aangemaakt",
     'deleted' => "Categorie verwijderd|Categorieën verwijderd",

--- a/translations/pt-br/categories.php
+++ b/translations/pt-br/categories.php
@@ -4,6 +4,7 @@ return [
 
     'actions' => "Ações de categoria",
     'category' => "Categoria|Categorias",
+    'confirm_nonempty_delete' => "Yes, I want to permanently delete this category and everything inside it",
     'create' => "Criar categoria",
     'created' => "Categoria criada",
     'deleted' => "Categoria deletada|Categorias deletadas",

--- a/translations/ro/categories.php
+++ b/translations/ro/categories.php
@@ -4,6 +4,7 @@ return [
 
     'actions' => "Acțiuni categoria",
     'category' => "Categorie|Categorii",
+    'confirm_nonempty_delete' => "Yes, I want to permanently delete this category and everything inside it",
     'create' => "Creați categorie",
     'created' => "Categorie creat",
     'deleted' => "Categorie șters|Categorii șters",

--- a/translations/ru/categories.php
+++ b/translations/ru/categories.php
@@ -4,6 +4,7 @@ return [
 
     'actions' => "Категория действия",
     'category' => "Категория",
+    'confirm_nonempty_delete' => "Yes, I want to permanently delete this category and everything inside it",
     'create' => "Создать категорию",
     'created' => "Категория создана",
     'deleted' => "Категория удалена|Категории удалены",

--- a/translations/sr/categories.php
+++ b/translations/sr/categories.php
@@ -4,6 +4,7 @@ return [
 
     'actions' => "Category actions",
     'category' => "Kategorija|Kategorije",
+    'confirm_nonempty_delete' => "Yes, I want to permanently delete this category and everything inside it",
     'create' => "Napravi kategoriju",
     'created' => "Kategorija napravljena",
     'deleted' => "Kategorija izbrisana|Kategorije izbrisane",

--- a/translations/sv/categories.php
+++ b/translations/sv/categories.php
@@ -4,6 +4,7 @@ return [
 
     'actions' => "Kategori åtgärder",
     'category' => "Kategori",
+    'confirm_nonempty_delete' => "Yes, I want to permanently delete this category and everything inside it",
     'create' => "Skapa kategori",
     'created' => "Kategori skapad",
     'deleted' => "Kategori utgår|Kategorier utgår",

--- a/translations/th/categories.php
+++ b/translations/th/categories.php
@@ -4,6 +4,7 @@ return [
 
     'actions' => 'จัดการหมวดหมู่',
     'category' => 'หมวดหมู่|หมวดหมู่',
+    'confirm_nonempty_delete' => "Yes, I want to permanently delete this category and everything inside it",
     'create' => 'เพิ่มหมวดหมู่',
     'created' => 'เพิ่มหมวดหมู่แล้ว',
     'deleted' => 'ลบหมวดหมู่แล้ว|ลบหมวดหมู่แล้ว',

--- a/translations/tr/categories.php
+++ b/translations/tr/categories.php
@@ -4,6 +4,7 @@ return [
 
     'actions' => "Kategori ayarları",
     'category' => "Kategori|Kategoriler",
+    'confirm_nonempty_delete' => "Yes, I want to permanently delete this category and everything inside it",
     'create' => "Kategori Oluştur",
     'created' => "Kategori oluşturuldu",
     'deleted' => "Kategori silindi|Kategoriler Silindi",

--- a/views/category/modals/delete.blade.php
+++ b/views/category/modals/delete.blade.php
@@ -6,6 +6,15 @@
 
     {{ trans('forum::general.generic_confirm') }}
 
+    @if(! $category->isEmpty())
+        <div class="form-check mt-3">
+            <input class="form-check-input" type="checkbox" value="1" name="force" id="forceDelete">
+            <label class="form-check-label" for="forceDelete">
+                {{ trans('forum::categories.confirm_nonempty_delete') }}
+            </label>
+        </div>
+    @endif
+
     @slot('actions')
         <button type="submit" class="btn btn-danger">{{ trans('forum::general.delete') }}</button>
     @endslot


### PR DESCRIPTION
This PR does the following:
- Updates category deletion to ensure any descendant categories, threads, and thread readers (read/unread status per thread) are removed
- Introduces a `force` checkbox in the front-end that shows up and must be checked when deleting a non-empty category
- Updates bulk thread deletion to ensure thread readers are removed