### PR TITLE
5.0: Ensure category visibility checks

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -65,7 +65,7 @@ $r->group(['prefix' => 'bulk', 'as' => 'bulk.', 'namespace' => 'Bulk'], function
 
 $r->bind('thread', function ($value)
 {
-    $thread = \TeamTeaTime\Forum\Models\Thread::withTrashed()->find($value);
+    $thread = \TeamTeaTime\Forum\Models\Thread::withTrashed()->with('category')->find($value);
 
     if ($thread->trashed() && ! Gate::allows('viewTrashedThreads')) return null;
 
@@ -74,7 +74,7 @@ $r->bind('thread', function ($value)
 
 $r->bind('post', function ($value)
 {
-    $post = \TeamTeaTime\Forum\Models\Post::withTrashed()->find($value);
+    $post = \TeamTeaTime\Forum\Models\Post::withTrashed()->with(['thread', 'thread.category'])->find($value);
 
     if ($post->trashed() && ! Gate::allows('viewTrashedPosts')) return null;
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,11 +16,11 @@ $r->post($prefix['category'] . '/create', ['as' => 'category.store', 'uses' => '
 $r->group(['prefix' => $prefix['category'] . '/{category}-{category_slug}'], function ($r) use ($prefix, $authMiddleware)
 {
     $r->get('/', ['as' => 'category.show', 'uses' => 'CategoryController@show']);
-    $r->patch('/', ['as' => 'category.update', 'uses' => 'CategoryController@update', 'middleware' => $authMiddleware]);
-    $r->delete('/', ['as' => 'category.delete', 'uses' => 'CategoryController@destroy', 'middleware' => $authMiddleware]);
+    $r->patch('/', ['as' => 'category.update', 'uses' => 'CategoryController@update'])->middleware($authMiddleware);
+    $r->delete('/', ['as' => 'category.delete', 'uses' => 'CategoryController@destroy'])->middleware($authMiddleware);
 
     $r->get($prefix['thread'] . '/create', ['as' => 'thread.create', 'uses' => 'ThreadController@create']);
-    $r->post($prefix['thread'] . '/create', ['as' => 'thread.store', 'uses' => 'ThreadController@store', 'middleware' => $authMiddleware]);
+    $r->post($prefix['thread'] . '/create', ['as' => 'thread.store', 'uses' => 'ThreadController@store'])->middleware($authMiddleware);
 });
 
 $r->group(['prefix' => $prefix['thread'] . '/{thread}-{thread_slug}'], function ($r) use ($prefix, $authMiddleware)
@@ -72,7 +72,7 @@ $r->bind('category', function ($value)
 
 $r->bind('thread', function ($value)
 {
-    $thread = \TeamTeaTime\Forum\Models\Thread::withTrashed()->find($value);
+    $thread = \TeamTeaTime\Forum\Models\Thread::withTrashed()->with('category')->find($value);
 
     if (is_null($thread)) abort(404);
 
@@ -83,7 +83,7 @@ $r->bind('thread', function ($value)
 
 $r->bind('post', function ($value)
 {
-    $post = \TeamTeaTime\Forum\Models\Post::withTrashed()->find($value);
+    $post = \TeamTeaTime\Forum\Models\Post::withTrashed()->with(['thread', 'thread.category'])->find($value);
 
     if (is_null($post)) abort(404);
 

--- a/src/Http/Controllers/Web/CategoryController.php
+++ b/src/Http/Controllers/Web/CategoryController.php
@@ -33,11 +33,6 @@ class CategoryController extends BaseController
 
     public function show(Request $request, Category $category): View
     {
-        if (! $category->isAccessibleTo($request->user()))
-        {
-            abort(404);
-        }
-
         event(new UserViewingCategory($request->user(), $category));
 
         $categories = $request->user() && $request->user()->can('moveCategories') ? Category::defaultOrder()->withDepth()->get() : [];

--- a/src/Http/Controllers/Web/PostController.php
+++ b/src/Http/Controllers/Web/PostController.php
@@ -21,12 +21,7 @@ class PostController extends BaseController
 {
     public function show(Request $request, Thread $thread, string $postSlug, Post $post): View
     {
-        $category = $thread->category;
-        
-        if (! $category->isAccessibleTo($request->user()))
-        {
-            abort(404);
-        }
+        $this->authorize('view', $post);
 
         event(new UserViewingPost($request->user(), $post));
 

--- a/src/Http/Controllers/Web/ThreadController.php
+++ b/src/Http/Controllers/Web/ThreadController.php
@@ -80,17 +80,13 @@ class ThreadController extends BaseController
 
     public function show(Request $request, Thread $thread): View
     {
-        $category = $thread->category;
-
-        if (! $category->isAccessibleTo($request->user()))
-        {
-            abort(404);
-        }
+        $this->authorize('view', $thread);
 
         event(new UserViewingThread($request->user(), $thread));
 
         $thread->markAsRead($request->user()->getKey());
 
+        $category = $thread->category;
         $categories = $request->user() && $request->user()->can('moveThreadsFrom', $category)
                     ? Category::acceptsThreads()->get()->toTree()
                     : [];

--- a/src/Http/Requests/Bulk/DeleteThreads.php
+++ b/src/Http/Requests/Bulk/DeleteThreads.php
@@ -27,10 +27,13 @@ class DeleteThreads extends FormRequest implements FulfillableRequest
     {
         // Eloquent is used here so that we get a collection of Thread instead of
         // stdClass in order for the gate to infer the policy to use.
-        $threads = Thread::whereIn('id', $this->validated()['threads'])->get();
+        $threads = Thread::whereIn('id', $this->validated()['threads'])->with('category')->get();
         foreach ($threads as $thread)
         {
-            if (! $this->user()->can('delete', $thread)) return false;
+            if (! ($this->user()->can('view', $category) || $this->user()->can('delete', $thread)))
+            {
+                return false;
+            }
         }
 
         return true;

--- a/src/Http/Requests/Bulk/MoveThreads.php
+++ b/src/Http/Requests/Bulk/MoveThreads.php
@@ -31,11 +31,19 @@ class MoveThreads extends FormRequest implements FulfillableRequest
 
     public function authorizeValidated(): bool
     {
-        if (! $this->user()->can('moveThreadsTo', $this->getDestinationCategory())) return false;
+        $destinationCategory = $this->getDestinationCategory();
+
+        if (! ($this->user()->can('view', $destinationCategory) || $this->user()->can('moveThreadsTo', $destinationCategory)))
+        {
+            return false;
+        }
 
         foreach ($this->getSourceCategories() as $category)
         {
-            if (! $this->user()->can('moveThreadsFrom', $category)) return false;
+            if (! ($this->user()->can('view', $category) || $this->user()->can('moveThreadsFrom', $category)))
+            {
+                return false;
+            }
         }
 
         return true;

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -87,9 +87,4 @@ class Category extends BaseModel
     {
         return $this->descendants->count() == 0 && $this->threads()->withTrashed()->count() == 0;
     }
-
-    public function isAccessibleTo(User $user = null): bool
-    {
-        return ! $this->is_private || (! is_null($user) && $user->can('view', $this));
-    }
 }

--- a/src/Policies/CategoryPolicy.php
+++ b/src/Policies/CategoryPolicy.php
@@ -8,7 +8,7 @@ class CategoryPolicy
 {
     public function createThreads($user, Category $category): bool
     {
-        return true;
+        return $this->view($user, $category);
     }
 
     public function manageThreads($user, Category $category): bool
@@ -22,42 +22,42 @@ class CategoryPolicy
 
     public function deleteThreads($user, Category $category): bool
     {
-        return true;
+        return $this->view($user, $category);
     }
 
     public function restoreThreads($user, Category $category): bool
     {
-        return true;
+        return $this->view($user, $category);
     }
 
     public function enableThreads($user, Category $category): bool
     {
-        return true;
+        return $this->view($user, $category);
     }
 
     public function moveThreadsFrom($user, Category $category): bool
     {
-        return true;
+        return $this->view($user, $category);
     }
 
     public function moveThreadsTo($user, Category $category): bool
     {
-        return true;
+        return $this->view($user, $category);
     }
 
     public function lockThreads($user, Category $category): bool
     {
-        return true;
+        return $this->view($user, $category);
     }
 
     public function pinThreads($user, Category $category): bool
     {
-        return true;
+        return $this->view($user, $category);
     }
 
     public function markThreadsAsRead($user, Category $category): bool
     {
-        return true;
+        return $this->view($user, $category);
     }
 
     public function view($user, Category $category): bool
@@ -67,11 +67,11 @@ class CategoryPolicy
 
     public function delete($user, Category $category): bool
     {
-        return true;
+        return $this->view($user, $category);
     }
 
     public function restore($user, Category $category): bool
     {
-        return true;
+        return $this->view($user, $category);
     }
 }

--- a/src/Policies/PostPolicy.php
+++ b/src/Policies/PostPolicy.php
@@ -4,21 +4,31 @@ namespace TeamTeaTime\Forum\Policies;
 
 use Illuminate\Support\Facades\Gate;
 use TeamTeaTime\Forum\Models\Post;
+use TeamTeaTime\Forum\Policies\Traits\ChecksCategoryVisibility;
 
 class PostPolicy
 {
+    use ChecksCategoryVisibility;
+
+    public function view($user, Post $post): bool
+    {
+        return $this->canUserViewCategory($user, $post->thread->category);
+    }
+
     public function edit($user, Post $post): bool
     {
-        return $user->getKey() === $post->author_id;
+        return $this->canUserViewCategory($user, $post->thread->category) && $user->getKey() === $post->author_id;
     }
 
     public function delete($user, Post $post): bool
     {
-        return Gate::forUser($user)->allows('deletePosts', $post->thread) || $user->getKey() === $post->author_id;
+        return $this->canUserViewCategory($user, $post->thread->category)
+            && Gate::forUser($user)->allows('deletePosts', $post->thread) || $user->getKey() === $post->author_id;
     }
 
     public function restore($user, Post $post): bool
     {
-        return Gate::forUser($user)->allows('restorePosts', $post->thread) || $user->getKey() === $post->author_id;
+        return $this->canUserViewCategory($user, $post->thread->category)
+            && Gate::forUser($user)->allows('restorePosts', $post->thread) || $user->getKey() === $post->author_id;
     }
 }

--- a/src/Policies/Traits/ChecksCategoryVisibility.php
+++ b/src/Policies/Traits/ChecksCategoryVisibility.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace TeamTeaTime\Forum\Policies\Traits;
+
+use Illuminate\Support\Facades\Gate;
+use TeamTeaTime\Forum\Models\Category;
+
+trait ChecksCategoryVisibility
+{
+    protected function canUserViewCategory($user, Category $category): bool
+    {
+        return ! $category->is_private || Gate::forUser($user)->allows('view', $category);
+    }
+}


### PR DESCRIPTION
This PR ensures all thread/post actions have relevant authorization checks and, where appropriate, ensures authorization checks incorporate a check for whether or not the user can view the parent category.

This does lead to some code duplication and an awkward trait, but it offers full flexibility to the package user in terms of what exactly to allow/deny - for example, this makes it easier to establish a forum category whereby users can only view their own threads and not those created by other users.

Note that it does not support checking the parents of nested categories, so it would be possible to have a private category with a non-private category inside it where threads would be publicly visible if the child category URL or thread URLs are known, but this was the case before too and should probably be left to the package user to handle how they see fit (e.g. override `CategoryPolicy::view` to traverse up the tree until it finds a private category and operate on that).