### PR TITLE
5.0: Add migration for creating category_id & thread_id indices

### DIFF
--- a/database/migrations/2021_07_31_094750_add_fk_indices.php
+++ b/database/migrations/2021_07_31_094750_add_fk_indices.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFkIndices extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('forum_threads', function (Blueprint $table) {
+            $table->index('category_id');
+        });
+
+        Schema::table('forum_posts', function (Blueprint $table) {
+            $table->index('thread_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('forum_threads', function (Blueprint $table) {
+            $table->dropIndex('category_id');
+        });
+
+        Schema::table('forum_posts', function (Blueprint $table) {
+            $table->dropIndex('thread_id');
+        });
+    }
+}

--- a/database/migrations/2021_07_31_094750_add_fk_indices.php
+++ b/database/migrations/2021_07_31_094750_add_fk_indices.php
@@ -30,11 +30,11 @@ class AddFkIndices extends Migration
     public function down()
     {
         Schema::table('forum_threads', function (Blueprint $table) {
-            $table->dropIndex('category_id');
+            $table->dropIndex('forum_threads_category_id_index');
         });
 
         Schema::table('forum_posts', function (Blueprint $table) {
-            $table->dropIndex('thread_id');
+            $table->dropIndex('forum_posts_thread_id_index');
         });
     }
 }


### PR DESCRIPTION
This PR adds a migration for creating indices on the `category_id` and `thread_id` foreign keys (see #212).