### PR TITLE
5.0: Retain soft deleted post refs

### DIFF
--- a/src/Actions/DeletePost.php
+++ b/src/Actions/DeletePost.php
@@ -42,12 +42,6 @@ class DeletePost extends BaseAction
             'post_count' => DB::raw('post_count - 1')
         ]);
 
-        if (! is_null($this->post->children))
-        {
-            // Other posts reference this one; null their post IDs
-            $this->post->children()->update(['post_id' => null]);
-        }
-
         // Update sequence numbers for all of the thread's posts
         $this->post->thread->posts->each(function ($p)
         {

--- a/src/Actions/DeletePost.php
+++ b/src/Actions/DeletePost.php
@@ -42,6 +42,12 @@ class DeletePost extends BaseAction
             'post_count' => DB::raw('post_count - 1')
         ]);
 
+        if ($this->permaDelete && ! is_null($this->post->children))
+        {
+            // Other posts reference this one; null their post IDs
+            $this->post->children()->update(['post_id' => null]);
+        }
+
         // Update sequence numbers for all of the thread's posts
         $this->post->thread->posts->each(function ($p)
         {


### PR DESCRIPTION
This PR changes the `DeletePost` action to limit nulling `post_id` FKs to permadeletion of the post. This allows replies to a soft-deleted post to retain the reference until the post is restored.

(See #207)