### PR TITLE
5.0: Optional user trait

### DIFF
--- a/src/Models/Traits/HasForumContent.php
+++ b/src/Models/Traits/HasForumContent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace TeamTeaTime\Forum\Models\Traits;
+
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use TeamTeaTime\Forum\Models\Thread;
+use TeamTeaTime\Forum\Models\Post;
+
+trait HasForumContent
+{
+    public function threads(): HasMany
+    {
+        return $this->hasMany(Thread::class, 'author_id');
+    }
+
+    public function posts(): HasMany
+    {
+        return $this->hasMany(Post::class, 'author_id');
+    }
+}


### PR DESCRIPTION
This PR adds a `HasForumContent` trait that can optionally be added to User models to provide relationships to threads and posts. Closes #221.