### PR TITLE
5.0: Query optimisation

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -32,7 +32,6 @@
     <rule ref="PEAR.ControlStructures.MultiLineCondition"/>
     <rule ref="PEAR.Formatting.MultiLineAssignment"/>
     <rule ref="PEAR.NamingConventions.ValidClassName"/>
-    <rule ref="PEAR.WhiteSpace.ObjectOperatorIndent"/>
     <rule ref="PEAR.WhiteSpace.ScopeClosingBrace"/>
     <rule ref="PSR1.Files.SideEffects"/>
     <rule ref="PSR2.Classes.ClassDeclaration"/>

--- a/src/Http/Controllers/Web/ThreadController.php
+++ b/src/Http/Controllers/Web/ThreadController.php
@@ -27,7 +27,7 @@ class ThreadController extends BaseController
 {
     public function recent(Request $request): View
     {
-        $threads = Thread::recent();
+        $threads = Thread::recent()->with('category', 'author', 'lastPost', 'lastPost.author');
 
         if ($request->has('category_id')) {
             $threads = $threads->where('category_id', $request->input('category_id'));
@@ -87,7 +87,11 @@ class ThreadController extends BaseController
         $posts = config('forum.general.display_trashed_posts') || $request->user() && $request->user()->can('viewTrashedPosts')
                ? $thread->posts()->withTrashed()
                : $thread->posts();
-        $posts = $posts->orderBy('created_at', 'asc')->paginate();
+
+        $posts = $posts
+            ->with('author', 'thread')
+            ->orderBy('created_at', 'asc')
+            ->paginate();
 
         return view('forum::thread.show', compact('categories', 'category', 'thread', 'posts'));
     }


### PR DESCRIPTION
This PR attempts to deduplicate DB queries by tuning eager loads. It eliminates duplicate queries on the index and thread views, and significantly reduces them elsewhere.