### PR TITLE
Fix post selection functionality

### DIFF
--- a/src/Http/Controllers/Web/ThreadController.php
+++ b/src/Http/Controllers/Web/ThreadController.php
@@ -102,7 +102,14 @@ class ThreadController extends BaseController
             ->orderBy('created_at', 'asc')
             ->paginate();
 
-        return ViewFactory::make('forum::thread.show', compact('categories', 'category', 'thread', 'posts'));
+        $selectablePosts = [];
+        foreach ($posts as $post) {
+            if ($request->user()->can('delete', $post) || $request->user()->can('restore', $post)) {
+                $selectablePosts[] = $post->id;
+            }
+        }
+
+        return ViewFactory::make('forum::thread.show', compact('categories', 'category', 'thread', 'posts', 'selectablePosts'));
     }
 
     public function create(Request $request, Category $category): View

--- a/views/thread/show.blade.php
+++ b/views/thread/show.blade.php
@@ -77,7 +77,7 @@
 
         <hr>
 
-        @if ((count($posts) > 1 || $posts->currentPage() > 1) && (Gate::allows('deletePosts', $thread) || Gate::allows('restorePosts', $thread)))
+        @if ((count($posts) > 1 || $posts->currentPage() > 1) && (Gate::allows('deletePosts', $thread) || Gate::allows('restorePosts', $thread)) && count($selectablePosts) > 0)
             <form :action="postActions[selectedPostAction]" method="POST">
                 @csrf
                 <input type="hidden" name="_method" :value="postActionMethods[selectedPostAction]" />
@@ -103,7 +103,7 @@
             </div>
         </div>
 
-        @if ((count($posts) > 1 || $posts->currentPage() > 1) && (Gate::allows('deletePosts', $thread) || Gate::allows('restorePosts', $thread)))
+        @if ((count($posts) > 1 || $posts->currentPage() > 1) && (Gate::allows('deletePosts', $thread) || Gate::allows('restorePosts', $thread)) && count($selectablePosts) > 0)
             <div class="text-end pb-1">
                 <div class="form-check">
                     <label for="selectAllPosts">
@@ -118,7 +118,7 @@
             @include ('forum::post.partials.list', compact('post'))
         @endforeach
 
-        @if ((count($posts) > 1 || $posts->currentPage() > 1) && (Gate::allows('deletePosts', $thread) || Gate::allows('restorePosts', $thread)))
+        @if ((count($posts) > 1 || $posts->currentPage() > 1) && (Gate::allows('deletePosts', $thread) || Gate::allows('restorePosts', $thread)) && count($selectablePosts) > 0)
                 <div class="fixed-bottom-right pb-xs-0 pr-xs-0 pb-sm-3 pr-sm-3">
                     <transition name="fade">
                         <div class="card text-white bg-secondary shadow-sm" v-if="selectedPosts.length">
@@ -352,6 +352,7 @@
         name: 'Thread',
         data: {
             posts: @json($posts),
+            selectablePosts: @json($selectablePosts),
             postActions: {
                 'delete': "{{ Forum::route('bulk.post.delete') }}",
                 'restore': "{{ Forum::route('bulk.post.restore') }}"
@@ -364,12 +365,6 @@
             selectedPosts: [],
             selectedThreadAction: null
         },
-        computed: {
-            postIds ()
-            {
-                return this.posts.data.map(post => post.id);
-            }
-        },
         created ()
         {
             this.posts.data = this.posts.data.filter(post => post.sequence != 1);
@@ -377,7 +372,7 @@
         methods: {
             toggleAll ()
             {
-                this.selectedPosts = (this.selectedPosts.length < this.posts.data.length) ? this.postIds : [];
+                this.selectedPosts = (this.selectedPosts.length < this.selectablePosts.length) ? this.selectablePosts : [];
             },
             submitThread (event)
             {


### PR DESCRIPTION
This PR fixes an issue with the post selection functionality in the frontend whereby the "select all" checkbox would show up even if none of the posts on the current page are eligible for selection. It now only shows up when there's at least one selectable post, and handles selection toggling accordingly.