### PR TITLE
Cascading privacy

### DIFF
--- a/src/Actions/MarkThreadsAsRead.php
+++ b/src/Actions/MarkThreadsAsRead.php
@@ -5,6 +5,7 @@ namespace TeamTeaTime\Forum\Actions;
 use Illuminate\Foundation\Auth\User;
 use TeamTeaTime\Forum\Models\Category;
 use TeamTeaTime\Forum\Models\Thread;
+use TeamTeaTime\Forum\Support\CategoryPrivacy;
 
 class MarkThreadsAsRead extends BaseAction
 {
@@ -25,10 +26,12 @@ class MarkThreadsAsRead extends BaseAction
             $threads = $threads->where('category_id', $this->category->id);
         }
 
+        $accessibleCategoryIds = CategoryPrivacy::getFilteredFor($this->user)->keys();
+
         $threads = $threads->get()->filter(function ($thread) {
             // @TODO: handle authorization check outside of action?
             return $thread->userReadStatus != null
-                && (! $thread->category->is_private || ($this->user->can('view', $thread->category) && $this->user->can('view', $thread)));
+                && (! $thread->category->is_private || ($accessibleCategoryIds->contains($thread->category_id) && $this->user->can('view', $thread)));
         });
 
         foreach ($threads as $thread) {

--- a/src/Http/Controllers/Api/BaseController.php
+++ b/src/Http/Controllers/Api/BaseController.php
@@ -17,6 +17,11 @@ abstract class BaseController
         ], 400);
     }
 
+    protected function notFoundResponse(): Response
+    {
+        return new Response(null, 404);
+    }
+
     protected function bulkActionResponse(int $rowsAffected, string $transKey): Response
     {
         return new Response([

--- a/src/Http/Controllers/Api/PostController.php
+++ b/src/Http/Controllers/Api/PostController.php
@@ -13,7 +13,6 @@ use TeamTeaTime\Forum\Http\Requests\UpdatePost;
 use TeamTeaTime\Forum\Http\Resources\PostResource;
 use TeamTeaTime\Forum\Models\Post;
 use TeamTeaTime\Forum\Models\Thread;
-use TeamTeaTime\Forum\Support\CategoryPrivacy;
 
 class PostController extends BaseController
 {

--- a/src/Http/Controllers/Api/ThreadController.php
+++ b/src/Http/Controllers/Api/ThreadController.php
@@ -19,7 +19,6 @@ use TeamTeaTime\Forum\Http\Requests\UnpinThread;
 use TeamTeaTime\Forum\Http\Resources\ThreadResource;
 use TeamTeaTime\Forum\Models\Category;
 use TeamTeaTime\Forum\Models\Thread;
-use TeamTeaTime\Forum\Support\CategoryPrivacy;
 
 class ThreadController extends BaseController
 {
@@ -27,7 +26,7 @@ class ThreadController extends BaseController
     {
         $threads = Thread::recent()
             ->get()
-            ->filter(function ($thread) use ($request, $unreadOnly, $accessibleCategoryIds) {
+            ->filter(function ($thread) use ($request, $unreadOnly) {
                 return $thread->category->isAccessibleTo($request->user())
                     && (! $unreadOnly || $thread->userReadStatus !== null)
                     && (

--- a/src/Http/Controllers/Web/CategoryController.php
+++ b/src/Http/Controllers/Web/CategoryController.php
@@ -38,6 +38,13 @@ class CategoryController extends BaseController
             UserViewingCategory::dispatch($request->user(), $category);
         }
 
+        $privateAncestor = $request->user() && $request->user()->can('manageCategories')
+            ? Category::defaultOrder()
+                ->where('is_private', true)
+                ->ancestorsOf($category->id)
+                ->first()
+            : [];
+
         $categories = $request->user() && $request->user()->can('moveCategories')
             ? Category::defaultOrder()
                 ->with('children')
@@ -55,7 +62,7 @@ class CategoryController extends BaseController
             ->orderBy('updated_at', 'desc')
             ->paginate();
 
-        return ViewFactory::make('forum::category.show', compact('categories', 'category', 'threads'));
+        return ViewFactory::make('forum::category.show', compact('privateAncestor', 'categories', 'category', 'threads'));
     }
 
     public function store(CreateCategory $request): RedirectResponse

--- a/src/Http/Controllers/Web/PostController.php
+++ b/src/Http/Controllers/Web/PostController.php
@@ -21,10 +21,12 @@ class PostController extends BaseController
 {
     public function show(Request $request, Thread $thread, string $postSlug, Post $post): View
     {
+        if (! $thread->category->isAccessibleTo($request->user())) {
+            abort(404);
+        }
+
         if ($thread->category->is_private) {
-            $this->authorize('view', $thread->category);
             $this->authorize('view', $thread);
-            $this->authorize('view', $post);
         }
 
         if ($request->user() !== null) {

--- a/src/Http/Requests/Bulk/DeleteThreads.php
+++ b/src/Http/Requests/Bulk/DeleteThreads.php
@@ -9,6 +9,7 @@ use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Http\Requests\Traits\HandlesDeletion;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Thread;
+use TeamTeaTime\Forum\Support\CategoryPrivacy;
 
 class DeleteThreads extends FormRequest implements FulfillableRequest
 {
@@ -27,8 +28,10 @@ class DeleteThreads extends FormRequest implements FulfillableRequest
         // Eloquent is used here so that we get a collection of Thread instead of
         // stdClass in order for the gate to infer the policy to use.
         $threads = Thread::whereIn('id', $this->validated()['threads'])->with('category')->get();
+        $accessibleCategoryIds = CategoryPrivacy::getFilteredFor($this->user())->keys();
+
         foreach ($threads as $thread) {
-            $canView = $this->user()->can('view', $thread->category) && $this->user()->can('view', $thread);
+            $canView = $accessibleCategoryIds->contains($thread->category_id) && $this->user()->can('view', $thread);
             $canDelete = $this->user()->can('deleteThreads', $thread->category) && $this->user()->can('delete', $thread);
 
             if (! ($canView && $canDelete)) {

--- a/src/Http/Requests/Bulk/MoveThreads.php
+++ b/src/Http/Requests/Bulk/MoveThreads.php
@@ -10,6 +10,7 @@ use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Category;
 use TeamTeaTime\Forum\Models\Thread;
+use TeamTeaTime\Forum\Support\CategoryPrivacy;
 
 class MoveThreads extends FormRequest implements FulfillableRequest
 {
@@ -30,12 +31,14 @@ class MoveThreads extends FormRequest implements FulfillableRequest
     {
         $destinationCategory = $this->getDestinationCategory();
 
-        if (! ($this->user()->can('view', $destinationCategory) || $this->user()->can('moveThreadsTo', $destinationCategory))) {
+        $accessibleCategoryIds = CategoryPrivacy::getFilteredFor($this->user())->keys();
+
+        if (! ($accessibleCategoryIds->contains($destinationCategory->id) || $this->user()->can('moveThreadsTo', $destinationCategory))) {
             return false;
         }
 
         foreach ($this->getSourceCategories() as $category) {
-            if (! ($this->user()->can('view', $category) || $this->user()->can('moveThreadsFrom', $category))) {
+            if (! ($accessibleCategoryIds->contains($category->id) || $this->user()->can('moveThreadsFrom', $category))) {
                 return false;
             }
         }

--- a/src/Http/Requests/MarkThreadsAsRead.php
+++ b/src/Http/Requests/MarkThreadsAsRead.php
@@ -8,7 +8,6 @@ use TeamTeaTime\Forum\Events\UserMarkedThreadsAsRead;
 use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Category;
-use TeamTeaTime\Forum\Support\CategoryPrivacy;
 
 class MarkThreadsAsRead extends FormRequest implements FulfillableRequest
 {

--- a/src/Http/Requests/MarkThreadsAsRead.php
+++ b/src/Http/Requests/MarkThreadsAsRead.php
@@ -8,6 +8,7 @@ use TeamTeaTime\Forum\Events\UserMarkedThreadsAsRead;
 use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Category;
+use TeamTeaTime\Forum\Support\CategoryPrivacy;
 
 class MarkThreadsAsRead extends FormRequest implements FulfillableRequest
 {
@@ -26,7 +27,7 @@ class MarkThreadsAsRead extends FormRequest implements FulfillableRequest
     {
         $category = $this->category();
 
-        if ($category !== null && ! $this->user()->can('view', $category)) {
+        if ($category !== null && ! $category->isAccessibleTo($this->user())) {
             return false;
         }
 

--- a/src/Http/Requests/SearchPosts.php
+++ b/src/Http/Requests/SearchPosts.php
@@ -8,7 +8,6 @@ use TeamTeaTime\Forum\Events\UserSearchedPosts;
 use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Category;
-use TeamTeaTime\Forum\Support\CategoryPrivacy;
 
 class SearchPosts extends FormRequest implements FulfillableRequest
 {

--- a/src/Http/Requests/SearchPosts.php
+++ b/src/Http/Requests/SearchPosts.php
@@ -8,6 +8,7 @@ use TeamTeaTime\Forum\Events\UserSearchedPosts;
 use TeamTeaTime\Forum\Http\Requests\Traits\AuthorizesAfterValidation;
 use TeamTeaTime\Forum\Interfaces\FulfillableRequest;
 use TeamTeaTime\Forum\Models\Category;
+use TeamTeaTime\Forum\Support\CategoryPrivacy;
 
 class SearchPosts extends FormRequest implements FulfillableRequest
 {
@@ -26,7 +27,7 @@ class SearchPosts extends FormRequest implements FulfillableRequest
     {
         $category = $this->getCategory();
 
-        return $category == null || ! $category->is_private || $this->user()->can('view', $category);
+        return $category == null || ! $category->is_private || $category->isAccessibleTo($this->user());
     }
 
     public function fulfill()

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -2,11 +2,13 @@
 
 namespace TeamTeaTime\Forum\Models;
 
+use Illuminate\Foundation\Auth\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Kalnoy\Nestedset\NodeTrait;
 use TeamTeaTime\Forum\Support\Web\Forum;
+use TeamTeaTime\Forum\Support\CategoryPrivacy;
 
 class Category extends BaseModel
 {
@@ -84,5 +86,10 @@ class Category extends BaseModel
     public function isEmpty(): bool
     {
         return $this->descendants->count() == 0 && $this->threads()->withTrashed()->count() == 0;
+    }
+
+    public function isAccessibleTo(?User $user): bool
+    {
+        return CategoryPrivacy::isAccessibleTo($user, $this->id);
     }
 }

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -2,13 +2,13 @@
 
 namespace TeamTeaTime\Forum\Models;
 
-use Illuminate\Foundation\Auth\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Foundation\Auth\User;
 use Kalnoy\Nestedset\NodeTrait;
-use TeamTeaTime\Forum\Support\Web\Forum;
 use TeamTeaTime\Forum\Support\CategoryPrivacy;
+use TeamTeaTime\Forum\Support\Web\Forum;
 
 class Category extends BaseModel
 {

--- a/src/Support/CategoryPrivacy.php
+++ b/src/Support/CategoryPrivacy.php
@@ -3,7 +3,6 @@
 namespace TeamTeaTime\Forum\Support;
 
 use Illuminate\Foundation\Auth\User;
-use Illuminate\Http\Request;
 use Kalnoy\Nestedset\Collection as NestedCollection;
 use TeamTeaTime\Forum\Models\Category;
 
@@ -26,7 +25,7 @@ class CategoryPrivacy
     {
         return static::getFilteredFor($user)->toTree();
     }
-    
+
     public static function getFilteredAncestorsFor(?User $user, int $categoryId, array $select = self::DEFAULT_SELECT, array $with = self::DEFAULT_WITH)
     {
         $categories = static::getQuery($select, $with)

--- a/src/Support/CategoryPrivacy.php
+++ b/src/Support/CategoryPrivacy.php
@@ -56,6 +56,7 @@ class CategoryPrivacy
 
     private static function getQuery(array $select = self::DEFAULT_SELECT, array $with = self::DEFAULT_WITH)
     {
+        // 'is_private' and 'parent_id' fields are required for filtering
         return Category::select(array_merge($select, ['is_private', 'parent_id']))
             ->with($with)
             ->defaultOrder();

--- a/src/Support/CategoryPrivacy.php
+++ b/src/Support/CategoryPrivacy.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace TeamTeaTime\Forum\Support;
+
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Http\Request;
+use Kalnoy\Nestedset\Collection as NestedCollection;
+use TeamTeaTime\Forum\Models\Category;
+
+class CategoryPrivacy
+{
+    const DEFAULT_SELECT = ['*'];
+    const DEFAULT_WITH = ['newestThread', 'latestActiveThread', 'newestThread.lastPost', 'latestActiveThread.lastPost'];
+
+    public static function isAccessibleTo(?User $user, int $categoryId)
+    {
+        return static::getFilteredAncestorsFor($user, $categoryId, $select = ['id'], $with = [])->keys()->contains($categoryId);
+    }
+
+    public static function getFilteredIdsFor(?User $user)
+    {
+        return static::getFilteredFor($user, $select = ['id'], $with = [])->keys();
+    }
+
+    public static function getFilteredTreeFor(?User $user)
+    {
+        return static::getFilteredFor($user)->toTree();
+    }
+    
+    public static function getFilteredAncestorsFor(?User $user, int $categoryId, array $select = self::DEFAULT_SELECT, array $with = self::DEFAULT_WITH)
+    {
+        $categories = static::getQuery($select, $with)
+            ->ancestorsAndSelf($categoryId)
+            ->keyBy('id');
+
+        return static::filter($categories, $user);
+    }
+
+    public static function getFilteredDescendantsFor(?User $user, int $categoryId, array $select = self::DEFAULT_SELECT, array $with = self::DEFAULT_WITH)
+    {
+        $categories = static::getQuery($select, $with)
+            ->descendantsAndSelf($categoryId)
+            ->keyBy('id');
+
+        return static::filter($categories, $user);
+    }
+
+    public static function getFilteredFor(?User $user, array $select = self::DEFAULT_SELECT, array $with = self::DEFAULT_WITH)
+    {
+        $categories = static::getQuery($select, $with)
+            ->get()
+            ->keyBy('id');
+
+        return static::filter($categories, $user);
+    }
+
+    private static function getQuery(array $select = self::DEFAULT_SELECT, array $with = self::DEFAULT_WITH)
+    {
+        return Category::select(array_merge($select, ['is_private', 'parent_id']))
+            ->with($with)
+            ->defaultOrder();
+    }
+
+    private static function filter(NestedCollection $categories, ?User $user, ?NestedCollection $rejected = null)
+    {
+        if ($rejected == null) {
+            $rejected = $categories->reject(function ($category, $id) use ($user) {
+                return ! $category->is_private || (! is_null($user) && $user->can('view', $category));
+            });
+        }
+
+        $categories = $categories->whereNotIn('id', $rejected->keys());
+        $rejected = $categories->whereIn('parent_id', $rejected->keys());
+
+        if ($rejected->count() > 0) {
+            $categories = static::filter($categories, $user, $rejected);
+        }
+
+        return $categories;
+    }
+}

--- a/src/Tests/Feature/Web/CategoryShowTest.php
+++ b/src/Tests/Feature/Web/CategoryShowTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace TeamTeaTime\Forum\Tests\Feature\Web;
+
+use Illuminate\Foundation\Auth\User;
+use Orchestra\Testbench\Factories\UserFactory;
+use TeamTeaTime\Forum\Database\Factories\CategoryFactory;
+use TeamTeaTime\Forum\Database\Factories\PostFactory;
+use TeamTeaTime\Forum\Database\Factories\ThreadFactory;
+use TeamTeaTime\Forum\Models\Category;
+use TeamTeaTime\Forum\Models\Post;
+use TeamTeaTime\Forum\Models\Thread;
+use TeamTeaTime\Forum\Support\Web\Forum;
+use TeamTeaTime\Forum\Tests\FeatureTestCase;
+
+class CategoryShowTest extends FeatureTestCase
+{
+    private const ROUTE = 'category.show';
+
+    private CategoryFactory $categoryFactory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->categoryFactory = CategoryFactory::new();
+    }
+
+    /** @test */
+    public function should_404_when_viewing_child_of_inaccessible_category()
+    {
+        $secondLevelCategory = $this->seedCategories();
+
+        $response = $this->get(Forum::route(self::ROUTE, $secondLevelCategory));
+        $response->assertStatus(404);
+    }
+
+    private function seedCategories(): Category
+    {
+        $topLevelCategory = $this->categoryFactory->createOne([
+            'is_private' => true
+        ]);
+        $secondLevelCategory = $this->categoryFactory->createOne();
+        $topLevelCategory->appendNode($secondLevelCategory);
+
+        return $secondLevelCategory;
+    }
+}

--- a/src/Tests/Feature/Web/CategoryShowTest.php
+++ b/src/Tests/Feature/Web/CategoryShowTest.php
@@ -2,14 +2,8 @@
 
 namespace TeamTeaTime\Forum\Tests\Feature\Web;
 
-use Illuminate\Foundation\Auth\User;
-use Orchestra\Testbench\Factories\UserFactory;
 use TeamTeaTime\Forum\Database\Factories\CategoryFactory;
-use TeamTeaTime\Forum\Database\Factories\PostFactory;
-use TeamTeaTime\Forum\Database\Factories\ThreadFactory;
 use TeamTeaTime\Forum\Models\Category;
-use TeamTeaTime\Forum\Models\Post;
-use TeamTeaTime\Forum\Models\Thread;
 use TeamTeaTime\Forum\Support\Web\Forum;
 use TeamTeaTime\Forum\Tests\FeatureTestCase;
 

--- a/translations/de/categories.php
+++ b/translations/de/categories.php
@@ -2,6 +2,7 @@
 
 return [
 
+    'access_controlled_by_private_ancestor' => 'The ancestor category :category is set as private and controls access to this category.',
     'actions' => 'Kategorie-Aktionen',
     'category' => 'Kategorie|Kategorien',
     'confirm_nonempty_delete' => 'Yes, I want to permanently delete this category and everything inside it',

--- a/translations/en/categories.php
+++ b/translations/en/categories.php
@@ -2,6 +2,7 @@
 
 return [
 
+    'access_controlled_by_private_ancestor' => 'The ancestor category :category is set as private and controls access to this category.',
     'actions' => 'Category actions',
     'category' => 'Category|Categories',
     'confirm_nonempty_delete' => 'Yes, I want to permanently delete this category and everything inside it',

--- a/translations/es/categories.php
+++ b/translations/es/categories.php
@@ -2,6 +2,7 @@
 
 return [
 
+    'access_controlled_by_private_ancestor' => 'The ancestor category :category is set as private and controls access to this category.',
     'actions' => 'Acciones categoría',
     'category' => 'Categoría|Categorías',
     'confirm_nonempty_delete' => 'Yes, I want to permanently delete this category and everything inside it',

--- a/translations/fr/categories.php
+++ b/translations/fr/categories.php
@@ -2,6 +2,7 @@
 
 return [
 
+    'access_controlled_by_private_ancestor' => 'The ancestor category :category is set as private and controls access to this category.',
     'actions' => 'Catégorie actions',
     'category' => 'Catégorie|Catégories',
     'confirm_nonempty_delete' => 'Yes, I want to permanently delete this category and everything inside it',

--- a/translations/it/categories.php
+++ b/translations/it/categories.php
@@ -2,6 +2,7 @@
 
 return [
 
+    'access_controlled_by_private_ancestor' => 'The ancestor category :category is set as private and controls access to this category.',
     'actions' => 'Azioni categoria',
     'category' => 'Categoria|Categorie',
     'confirm_nonempty_delete' => 'Yes, I want to permanently delete this category and everything inside it',

--- a/translations/nl/categories.php
+++ b/translations/nl/categories.php
@@ -2,6 +2,7 @@
 
 return [
 
+    'access_controlled_by_private_ancestor' => 'The ancestor category :category is set as private and controls access to this category.',
     'actions' => 'Categorie acties',
     'category' => 'Categorie|Categorieën',
     'confirm_nonempty_delete' => 'Ik bevestig dat ik hiermee permanent de categorie en alle gegevens die hier onder hangen verwijder',

--- a/translations/pt-br/categories.php
+++ b/translations/pt-br/categories.php
@@ -2,6 +2,7 @@
 
 return [
 
+    'access_controlled_by_private_ancestor' => 'The ancestor category :category is set as private and controls access to this category.',
     'actions' => 'Ações de categoria',
     'category' => 'Categoria|Categorias',
     'confirm_nonempty_delete' => 'Yes, I want to permanently delete this category and everything inside it',

--- a/translations/ro/categories.php
+++ b/translations/ro/categories.php
@@ -2,6 +2,7 @@
 
 return [
 
+    'access_controlled_by_private_ancestor' => 'The ancestor category :category is set as private and controls access to this category.',
     'actions' => 'Acțiuni categoria',
     'category' => 'Categorie|Categorii',
     'confirm_nonempty_delete' => 'Yes, I want to permanently delete this category and everything inside it',

--- a/translations/ru/categories.php
+++ b/translations/ru/categories.php
@@ -2,6 +2,7 @@
 
 return [
 
+    'access_controlled_by_private_ancestor' => 'The ancestor category :category is set as private and controls access to this category.',
     'actions' => 'Категория действия',
     'category' => 'Категория',
     'confirm_nonempty_delete' => 'Yes, I want to permanently delete this category and everything inside it',

--- a/translations/sr/categories.php
+++ b/translations/sr/categories.php
@@ -2,6 +2,7 @@
 
 return [
 
+    'access_controlled_by_private_ancestor' => 'The ancestor category :category is set as private and controls access to this category.',
     'actions' => 'Category actions',
     'category' => 'Kategorija|Kategorije',
     'confirm_nonempty_delete' => 'Yes, I want to permanently delete this category and everything inside it',

--- a/translations/sv/categories.php
+++ b/translations/sv/categories.php
@@ -2,6 +2,7 @@
 
 return [
 
+    'access_controlled_by_private_ancestor' => 'The ancestor category :category is set as private and controls access to this category.',
     'actions' => 'Kategori åtgärder',
     'category' => 'Kategori',
     'confirm_nonempty_delete' => 'Yes, I want to permanently delete this category and everything inside it',

--- a/translations/th/categories.php
+++ b/translations/th/categories.php
@@ -2,6 +2,7 @@
 
 return [
 
+    'access_controlled_by_private_ancestor' => 'The ancestor category :category is set as private and controls access to this category.',
     'actions' => 'จัดการหมวดหมู่',
     'category' => 'หมวดหมู่|หมวดหมู่',
     'confirm_nonempty_delete' => 'Yes, I want to permanently delete this category and everything inside it',

--- a/translations/tr/categories.php
+++ b/translations/tr/categories.php
@@ -2,6 +2,7 @@
 
 return [
 
+    'access_controlled_by_private_ancestor' => 'The ancestor category :category is set as private and controls access to this category.',
     'actions' => 'Kategori ayarları',
     'category' => 'Kategori|Kategoriler',
     'confirm_nonempty_delete' => 'Yes, I want to permanently delete this category and everything inside it',

--- a/views/category/modals/edit.blade.php
+++ b/views/category/modals/edit.blade.php
@@ -22,10 +22,16 @@
     <div class="mb-3">
         <div class="form-check">
             <input type="hidden" name="is_private" value="0" />
-            <input class="form-check-input" type="checkbox" name="is_private" id="is-private" value="1" {{ $category->is_private ? 'checked' : '' }}>
+            <input class="form-check-input" type="checkbox" name="is_private" id="is-private" value="1" {{ $category->is_private ? 'checked' : '' }} {{ $privateAncestor != null ? 'disabled' : '' }}>
             <label class="form-check-label" for="is-private">{{ trans('forum::categories.make_private') }}</label>
         </div>
     </div>
+    @if ($privateAncestor != null)
+        <div class="alert alert-primary" role="alert">
+            {!! trans('forum::categories.access_controlled_by_private_ancestor', ['category' => "<a href=\"{$privateAncestor->route}\">{$privateAncestor->title}</a>"]) !!}
+        </div>
+    @endif
+
     @include ('forum::category.partials.inputs.color')
 
     @slot('actions')


### PR DESCRIPTION
**Issue:** #277 

This PR changes category privacy so that it cascades to descendants and updates the category edit modal to inform the user when it applies.

Notes about the new behaviour:
- If an authorization check for a given private category fails, access is also denied to all of that category's descendants, including private ones (they receive no authorization checks, so they cannot override the result).
- If an authorization check for a given private category succeeds, access is granted to that category's descendants **except** for any private ones that fail an authorization check.
- Public categories are always inaccessible when they have one or more inaccessible ancestors.

## Changelog
- Added `CategoryPrivacy` utility class to provide ways of filtering and checking access to categories.
- Updated controllers, requests, and actions to utilise the above utility and enforce privacy cascading.
- Updated the frontend to communicate privacy cascading to the user when it affects a category they're editing.
- Added `CategoryShowTest` to test access to private categories and their ancestors.

## Screenshots

![image](https://user-images.githubusercontent.com/3583774/141846015-1cf8fa45-5d80-4617-a047-fdf40b9022d8.png)