### PR TITLE
Fix inconsistencies in category and thread ability checks

### DIFF
--- a/src/Http/Controllers/Web/CategoryController.php
+++ b/src/Http/Controllers/Web/CategoryController.php
@@ -66,6 +66,8 @@ class CategoryController extends BaseController
         $selectableThreadIds = [];
         if ($request->user()) {
             if (Gate::any(['moveThreadsFrom', 'lockThreads', 'pinThreads'], $category)) {
+                // There are no thread-specific abilities corresponding to these,
+                // so we can include all of the threads for this page
                 $selectableThreadIds = $threads->pluck('id')->toArray();
             } else {
                 $canDeleteThreads = $request->user()->can('deleteThreads', $category);

--- a/src/Http/Controllers/Web/CategoryController.php
+++ b/src/Http/Controllers/Web/CategoryController.php
@@ -73,11 +73,13 @@ class CategoryController extends BaseController
                 $canDeleteThreads = $request->user()->can('deleteThreads', $category);
                 $canRestoreThreads = $request->user()->can('restoreThreads', $category);
 
-                foreach ($threads as $thread) {
-                    if (($canDeleteThreads && $request->user()->can('delete', $thread))
-                        || $canRestoreThreads && $request->user()->can('restore', $thread)
-                    ) {
-                        $selectableThreadIds[] = $thread->id;
+                if ($canDeleteThreads || $canRestoreThreads) {
+                    foreach ($threads as $thread) {
+                        if (($canDeleteThreads && $request->user()->can('delete', $thread))
+                            || $canRestoreThreads && $request->user()->can('restore', $thread)
+                        ) {
+                            $selectableThreadIds[] = $thread->id;
+                        }
                     }
                 }
             }

--- a/src/Http/Controllers/Web/CategoryController.php
+++ b/src/Http/Controllers/Web/CategoryController.php
@@ -62,7 +62,7 @@ class CategoryController extends BaseController
             ->orderBy('pinned', 'desc')
             ->orderBy('updated_at', 'desc')
             ->paginate();
-        
+
         $selectableThreadIds = [];
         if ($request->user()) {
             if (Gate::any(['moveThreadsFrom', 'lockThreads', 'pinThreads'], $category)) {
@@ -73,7 +73,8 @@ class CategoryController extends BaseController
 
                 foreach ($threads as $thread) {
                     if (($canDeleteThreads && $request->user()->can('delete', $thread))
-                        || $canRestoreThreads && $request->user()->can('restore', $thread)) {
+                        || $canRestoreThreads && $request->user()->can('restore', $thread)
+                    ) {
                         $selectableThreadIds[] = $thread->id;
                     }
                 }

--- a/src/Http/Controllers/Web/CategoryController.php
+++ b/src/Http/Controllers/Web/CategoryController.php
@@ -4,6 +4,7 @@ namespace TeamTeaTime\Forum\Http\Controllers\Web;
 
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\View as ViewFactory;
 use Illuminate\View\View;
 use TeamTeaTime\Forum\Events\UserViewingCategory;
@@ -61,8 +62,25 @@ class CategoryController extends BaseController
             ->orderBy('pinned', 'desc')
             ->orderBy('updated_at', 'desc')
             ->paginate();
+        
+        $selectableThreadIds = [];
+        if ($request->user()) {
+            if (Gate::any(['moveThreadsFrom', 'lockThreads', 'pinThreads'], $category)) {
+                $selectableThreadIds = $threads->pluck('id')->toArray();
+            } else {
+                $canDeleteThreads = $request->user()->can('deleteThreads', $category);
+                $canRestoreThreads = $request->user()->can('restoreThreads', $category);
 
-        return ViewFactory::make('forum::category.show', compact('privateAncestor', 'categories', 'category', 'threads'));
+                foreach ($threads as $thread) {
+                    if (($canDeleteThreads && $request->user()->can('delete', $thread))
+                        || $canRestoreThreads && $request->user()->can('restore', $thread)) {
+                        $selectableThreadIds[] = $thread->id;
+                    }
+                }
+            }
+        }
+
+        return ViewFactory::make('forum::category.show', compact('privateAncestor', 'categories', 'category', 'threads', 'selectableThreadIds'));
     }
 
     public function store(CreateCategory $request): RedirectResponse

--- a/src/Policies/CategoryPolicy.php
+++ b/src/Policies/CategoryPolicy.php
@@ -14,8 +14,10 @@ class CategoryPolicy
     public function manageThreads($user, Category $category): bool
     {
         return $this->deleteThreads($user, $category) ||
+               $this->restoreThreads($user, $category) ||
                $this->enableThreads($user, $category) ||
                $this->moveThreadsFrom($user, $category) ||
+               $this->moveThreadsTo($user, $category) ||
                $this->lockThreads($user, $category) ||
                $this->pinThreads($user, $category);
     }

--- a/src/Policies/CategoryPolicy.php
+++ b/src/Policies/CategoryPolicy.php
@@ -15,9 +15,7 @@ class CategoryPolicy
     {
         return $this->deleteThreads($user, $category) ||
                $this->restoreThreads($user, $category) ||
-               $this->enableThreads($user, $category) ||
                $this->moveThreadsFrom($user, $category) ||
-               $this->moveThreadsTo($user, $category) ||
                $this->lockThreads($user, $category) ||
                $this->pinThreads($user, $category);
     }

--- a/views/category/show.blade.php
+++ b/views/category/show.blade.php
@@ -46,7 +46,7 @@
                                 <label for="selectAllThreads">
                                     {{ trans('forum::threads.select_all') }}
                                 </label>
-                                <input type="checkbox" value="" id="selectAllThreads" class="align-middle" @click="toggleAll" :checked="selectedThreads.length == threads.data.length">
+                                <input type="checkbox" value="" id="selectAllThreads" class="align-middle" @click="toggleAll" :checked="selectedThreads.length == selectableThreadIds.length">
                             </div>
                         </div>
                 @endcan
@@ -187,7 +187,6 @@
         el: '.v-category-show',
         name: 'CategoryShow',
         data: {
-            threads: @json($threads),
             selectableThreadIds: @json($selectableThreadIds),
             actions: {
                 'delete': "{{ Forum::route('bulk.thread.delete') }}",

--- a/views/category/show.blade.php
+++ b/views/category/show.blade.php
@@ -58,7 +58,7 @@
                 </div>
 
                 @can ('manageThreads', $category)
-                        <div class="fixed-bottom-right pb-xs-0 pr-xs-0 pb-sm-3 pr-sm-3" style="z-index: 1000;">
+                        <div class="fixed-bottom-right pb-xs-0 pr-xs-0 pb-sm-3 pr-sm-3 m-2" style="z-index: 1000;">
                             <transition name="fade">
                                 <div class="card text-white bg-secondary shadow-sm" v-if="selectedThreads.length">
                                     <div class="card-header text-center">
@@ -69,9 +69,11 @@
                                             <div class="input-group-prepend">
                                                 <label class="input-group-text" for="bulk-actions">{{ trans_choice('forum::general.actions', 1) }}</label>
                                             </div>
-                                            <select class="custom-select" id="bulk-actions" v-model="selectedAction">
+                                            <select class="form-select" id="bulk-actions" v-model="selectedAction">
                                                 @can ('deleteThreads', $category)
                                                     <option value="delete">{{ trans('forum::general.delete') }}</option>
+                                                @endcan
+                                                @can ('restoreThreads', $category)
                                                     <option value="restore">{{ trans('forum::general.restore') }}</option>
                                                 @endcan
                                                 @can ('moveThreadsFrom', $category)
@@ -90,7 +92,7 @@
 
                                         <div class="mb-3" v-if="selectedAction == 'move'">
                                             <label for="category-id">{{ trans_choice('forum::categories.category', 1) }}</label>
-                                            <select name="category_id" id="category-id" class="form-control">
+                                            <select name="category_id" id="category-id" class="form-select">
                                                 @include ('forum::category.partials.options', ['hide' => $category])
                                             </select>
                                         </div>
@@ -105,7 +107,7 @@
                                         @endif
 
                                         <div class="text-end">
-                                            <button type="submit" class="btn btn-primary" @click="submit">{{ trans('forum::general.proceed') }}</button>
+                                            <button type="submit" class="btn btn-primary" @click="submit" :disabled="selectedAction == null">{{ trans('forum::general.proceed') }}</button>
                                         </div>
                                     </div>
                                 </div>
@@ -142,7 +144,7 @@
 
     @if (! $threads->isEmpty())
         @can ('markThreadsAsRead')
-            <div class="text-center">
+            <div class="text-center mt-3">
                 <button class="btn btn-primary px-5" data-open-modal="mark-threads-as-read">
                     <i data-feather="book"></i> {{ trans('forum::general.mark_read') }}
                 </button>
@@ -186,6 +188,7 @@
         name: 'CategoryShow',
         data: {
             threads: @json($threads),
+            selectableThreadIds: @json($selectableThreadIds),
             actions: {
                 'delete': "{{ Forum::route('bulk.thread.delete') }}",
                 'restore': "{{ Forum::route('bulk.thread.restore') }}",
@@ -202,21 +205,15 @@
                 'pin': 'POST',
                 'unpin': 'POST'
             },
-            selectedAction: 'delete',
+            selectedAction: null,
             selectedThreads: [],
             isEditModalOpen: false,
             isDeleteModalOpen: false
         },
-        computed: {
-            threadIds ()
-            {
-                return this.threads.data.map(thread => thread.id);
-            }
-        },
         methods: {
             toggleAll ()
             {
-                this.selectedThreads = (this.selectedThreads.length < this.threads.data.length) ? this.threadIds : [];
+                this.selectedThreads = (this.selectedThreads.length < this.selectableThreadIds.length) ? this.selectableThreadIds : [];
             },
             submit (event)
             {

--- a/views/thread/partials/list.blade.php
+++ b/views/thread/partials/list.blade.php
@@ -40,12 +40,10 @@
             </div>
         @endif
 
-        @if (isset($category))
-            @can ('manageThreads', $category)
-                <div class="col-sm" style="flex: 0;">
-                    <input type="checkbox" name="threads[]" :value="{{ $thread->id }}" v-model="selectedThreads">
-                </div>
-            @endcan
+        @if (isset($category) && isset($selectableThreadIds) && in_array($thread->id, $selectableThreadIds))
+            <div class="col-sm" style="flex: 0;">
+                <input type="checkbox" name="threads[]" :value="{{ $thread->id }}" v-model="selectedThreads">
+            </div>
         @endif
     </div>
 </div>


### PR DESCRIPTION
This PR fixes several inconsistencies in how category and thread abilities are checked.

## Changelog
+ Updated `ThreadPolicy::delete` and `ThreadPolicy::restore` ability checks so that they're always preceded by `CategoryPolicy::deleteThreads` and `CategoryPolicy::restoreThreads` checks respectively.
+ Updated `Web\CategoryController::show` to compile a list of selectable thread IDs by checking whether the user can move, lock, or pin threads in the category (in which case the list includes all threads in the current page) OR has permission to delete or restore specific threads (in which case the list only includes those threads).
+ Updated `CategoryPolicy::manageThreads` to better reflect whether the user can manage threads in the given category.
+ Updated the `category.show`, `thread.partials.list`, and `thread.show` views:
  + Implemented the new `selectableThreadIds` array to determine which threads should have a checkbox in the `category.show` view.
  + Fixed inconsistent or incorrect ability checks.
  + Fixed some minor style and UX issues.
  + Fixed an issue preventing the bulk thread actions popup from hiding the "Permanently delete" option when the "Delete" action isn't selected.

---

This PR should also fix #281.