### PR TITLE
Fix stat changes when moving threads

### DIFF
--- a/src/Actions/Bulk/MoveThreads.php
+++ b/src/Actions/Bulk/MoveThreads.php
@@ -42,7 +42,9 @@ class MoveThreads extends BaseAction
 
         $seen = [];
         foreach ($sourceCategories as $category) {
-            if (in_array($category->id, $seen)) continue;
+            if (in_array($category->id, $seen)) {
+                continue;
+            }
 
             $categoryThreads = $threadsByCategory->get($category->id);
             $threadCount = $categoryThreads->count();

--- a/src/Actions/Bulk/MoveThreads.php
+++ b/src/Actions/Bulk/MoveThreads.php
@@ -40,7 +40,10 @@ class MoveThreads extends BaseAction
 
         $query->update(['category_id' => $destinationCategory->id]);
 
+        $seen = [];
         foreach ($sourceCategories as $category) {
+            if (in_array($category->id, $seen)) continue;
+
             $categoryThreads = $threadsByCategory->get($category->id);
             $threadCount = $categoryThreads->count();
             $postCount = $threadCount + $categoryThreads->sum('reply_count');
@@ -50,6 +53,8 @@ class MoveThreads extends BaseAction
                 'thread_count' => DB::raw("thread_count - {$threadCount}"),
                 'post_count' => DB::raw("post_count - {$postCount}"),
             ]);
+
+            $seen[] = $category->id;
         }
 
         $threadCount = $threads->count();

--- a/src/Events/UserBulkMovedThreads.php
+++ b/src/Events/UserBulkMovedThreads.php
@@ -3,6 +3,7 @@
 namespace TeamTeaTime\Forum\Events;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as SupportCollection;
 use TeamTeaTime\Forum\Events\Types\CollectionEvent;
 use TeamTeaTime\Forum\Models\Category;
 
@@ -11,7 +12,7 @@ class UserBulkMovedThreads extends CollectionEvent
     public Collection $sourceCategories;
     public Category $destinationCategory;
 
-    public function __construct($user, Collection $threads, Collection $sourceCategories, Category $destinationCategory)
+    public function __construct($user, SupportCollection $threads, Collection $sourceCategories, Category $destinationCategory)
     {
         parent::__construct($user, $threads);
 


### PR DESCRIPTION
This PR fixes two issues that occur when moving threads - namely:

* Selecting more than one thread causes the source category's stats to be processed incorrectly (once per thread).
* Moving threads causes their timestamps to be touched.