### PR TITLE
Use Bootstrap 4 pagination view

### DIFF
--- a/views/category/show.blade.php
+++ b/views/category/show.blade.php
@@ -36,7 +36,7 @@
 
         @if ($category->accepts_threads)
             @if (! $threads->isEmpty())
-                {{ $threads->links() }}
+                {{ $threads->links('forum::pagination') }}
 
                 @if (count($selectableThreadIds) > 0)
                     @can ('manageThreads', $category)
@@ -135,7 +135,7 @@
 
             <div class="row">
                 <div class="col col-xs-8">
-                    {{ $threads->links() }}
+                    {{ $threads->links('forum::pagination') }}
                 </div>
                 <div class="col col-xs-4 text-end">
                     @if ($category->accepts_threads)

--- a/views/pagination.blade.php
+++ b/views/pagination.blade.php
@@ -1,0 +1,46 @@
+@if ($paginator->hasPages())
+    <nav>
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                    <span class="page-link" aria-hidden="true">&lsaquo;</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                </li>
+            @endif
+
+            {{-- Pagination Elements --}}
+            @foreach ($elements as $element)
+                {{-- "Three Dots" Separator --}}
+                @if (is_string($element))
+                    <li class="page-item disabled" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+                @endif
+
+                {{-- Array Of Links --}}
+                @if (is_array($element))
+                    @foreach ($element as $page => $url)
+                        @if ($page == $paginator->currentPage())
+                            <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                        @else
+                            <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                        @endif
+                    @endforeach
+                @endif
+            @endforeach
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                    <span class="page-link" aria-hidden="true">&rsaquo;</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/views/thread/show.blade.php
+++ b/views/thread/show.blade.php
@@ -90,7 +90,7 @@
 
         <div class="row mb-3">
             <div class="col col-xs-8">
-                {{ $posts->links() }}
+                {{ $posts->links('forum::pagination') }}
             </div>
             <div class="col-md-auto text-end">
                 @if (! $thread->trashed())
@@ -160,7 +160,7 @@
             </form>
         @endif
 
-        {{ $posts->links() }}
+        {{ $posts->links('forum::pagination') }}
 
         @if (! $thread->trashed())
             @can ('reply', $thread)


### PR DESCRIPTION
This PR forces the use of the Bootstrap 4 compatible pagination view that ships with Laravel instead of the default one.