### PR TITLE
Improve eager loading for thread listings

### DIFF
--- a/src/Http/Controllers/Web/CategoryController.php
+++ b/src/Http/Controllers/Web/CategoryController.php
@@ -58,7 +58,7 @@ class CategoryController extends BaseController
             : $category->threads();
 
         $threads = $threads
-            ->with('firstPost', 'lastPost', 'firstPost.author', 'lastPost.author', 'author')
+            ->with('firstPost', 'lastPost', 'firstPost.author', 'lastPost.author', 'lastPost.thread', 'author')
             ->orderBy('pinned', 'desc')
             ->orderBy('updated_at', 'desc')
             ->paginate();

--- a/src/Http/Controllers/Web/ThreadController.php
+++ b/src/Http/Controllers/Web/ThreadController.php
@@ -29,7 +29,7 @@ class ThreadController extends BaseController
 {
     public function recent(Request $request): View
     {
-        $threads = Thread::recent()->with('category', 'author', 'lastPost', 'lastPost.author');
+        $threads = Thread::recent()->with('category', 'author', 'lastPost', 'lastPost.author', 'lastPost.thread');
 
         if ($request->has('category_id')) {
             $threads = $threads->where('category_id', $request->input('category_id'));
@@ -50,7 +50,7 @@ class ThreadController extends BaseController
 
     public function unread(Request $request): View
     {
-        $threads = Thread::recent();
+        $threads = Thread::recent()->with('category', 'author', 'lastPost', 'lastPost.author', 'lastPost.thread');
 
         $accessibleCategoryIds = CategoryPrivacy::getFilteredFor($request->user())->keys();
 


### PR DESCRIPTION
This PR updates a few `->with()` statements to improve eager loading for thread listings.

See related PR: #300 