### PR TITLE
Fix Delete Thread action

### DIFF
--- a/src/Actions/DeleteThread.php
+++ b/src/Actions/DeleteThread.php
@@ -19,14 +19,12 @@ class DeleteThread extends BaseAction
     protected function transact()
     {
         $threadAlreadyTrashed = $this->thread->trashed();
-        $postsRemoved = 0;
+        $postsRemoved = $this->thread->postCount;
 
         if ($this->permaDelete) {
             $this->thread->readers()->detach();
             $this->thread->posts()->withTrashed()->forceDelete();
             $this->thread->forceDelete();
-
-            $postsRemoved = $this->thread->postCount;
         } else {
             // Return early if the thread was already trashed because there's nothing to do
             if ($threadAlreadyTrashed) {
@@ -37,28 +35,30 @@ class DeleteThread extends BaseAction
             $this->thread->deleteWithoutTouch();
         }
 
-        // Only update category stats and FKs if the thread wasn't already soft-deleted,
-        // otherwise they'll needlessly be updated a second time
-        if (! $threadAlreadyTrashed) {
-            $attributes = [
-                'thread_count' => DB::raw('thread_count - 1'),
-            ];
-
-            if ($postsRemoved) {
-                $attributes['post_count'] = DB::raw("post_count - {$postsRemoved}");
-            }
-
-            $category = $this->thread->category;
-
-            if ($category->newest_thread_id === $this->thread->id) {
-                $attributes['newest_thread_id'] = $category->getNewestThreadId();
-            }
-            if ($category->latest_active_thread_id === $this->thread->id) {
-                $attributes['latest_active_thread_id'] = $category->getLatestActiveThreadId();
-            }
-
-            $category->update($attributes);
+        // The thread was already trashed - skip stat/attribute updates since they were done
+        // previously.
+        if ($threadAlreadyTrashed) {
+            return $this->thread;
         }
+
+        $attributes = [
+            'thread_count' => DB::raw('thread_count - 1'),
+        ];
+
+        if ($postsRemoved) {
+            $attributes['post_count'] = DB::raw("post_count - {$postsRemoved}");
+        }
+
+        $category = $this->thread->category;
+
+        if ($category->newest_thread_id === $this->thread->id) {
+            $attributes['newest_thread_id'] = $category->getNewestThreadId();
+        }
+        if ($category->latest_active_thread_id === $this->thread->id) {
+            $attributes['latest_active_thread_id'] = $category->getLatestActiveThreadId();
+        }
+
+        $category->update($attributes);
 
         return $this->thread;
     }


### PR DESCRIPTION
This corrects the Delete Thread action so that it always counts the number of posts removed instead of only when permanently deleting a thread (i.e. this solves the issue of post count not going down when soft-deleting a thread).

Also switches some logic around a little to do an early return.