### PR TITLE
Move route model binding outside of route groups

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -71,27 +71,3 @@ Route::group(['prefix' => 'bulk', 'as' => 'bulk.', 'namespace' => 'Bulk'], funct
         Route::post('restore', ['as' => 'restore', 'uses' => 'PostController@restore']);
     });
 });
-
-Route::bind('category', function ($value) {
-    return \TeamTeaTime\Forum\Models\Category::find($value);
-});
-
-Route::bind('thread', function ($value) {
-    $query = \TeamTeaTime\Forum\Models\Thread::with('category');
-
-    if (Gate::allows('viewTrashedThreads')) {
-        $query->withTrashed();
-    }
-
-    return $query->find($value);
-});
-
-Route::bind('post', function ($value) {
-    $query = \TeamTeaTime\Forum\Models\Post::with(['thread', 'thread.category']);
-
-    if (Gate::allows('viewTrashedPosts')) {
-        $query->withTrashed();
-    }
-
-    return $query->find($value);
-});

--- a/routes/web.php
+++ b/routes/web.php
@@ -73,39 +73,3 @@ Route::group(['prefix' => 'bulk', 'as' => 'bulk.', 'namespace' => 'Bulk', 'middl
         Route::post('restore', ['as' => 'restore', 'uses' => 'PostController@restore']);
     });
 });
-
-Route::bind('category', function ($value) {
-    return \TeamTeaTime\Forum\Models\Category::findOrFail($value);
-});
-
-Route::bind('thread', function ($value) {
-    $query = \TeamTeaTime\Forum\Models\Thread::with('category');
-
-    if (Gate::allows('viewTrashedThreads')) {
-        $query->withTrashed();
-    }
-
-    $thread = $query->find($value);
-
-    if ($thread === null) {
-        abort(404);
-    }
-
-    return $thread;
-});
-
-Route::bind('post', function ($value) {
-    $query = \TeamTeaTime\Forum\Models\Post::with(['thread', 'thread.category']);
-
-    if (Gate::allows('viewTrashedPosts')) {
-        $query->withTrashed();
-    }
-
-    $post = $query->find($value);
-
-    if ($post === null) {
-        abort(404);
-    }
-
-    return $post;
-});

--- a/src/ForumServiceProvider.php
+++ b/src/ForumServiceProvider.php
@@ -14,8 +14,8 @@ use Illuminate\Support\ServiceProvider;
 use TeamTeaTime\Forum\Console\Commands\Seed;
 use TeamTeaTime\Forum\Console\Commands\SyncStats;
 use TeamTeaTime\Forum\Models\Category;
-use TeamTeaTime\Forum\Models\Thread;
 use TeamTeaTime\Forum\Models\Post;
+use TeamTeaTime\Forum\Models\Thread;
 
 class ForumServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
This PR moves route model bindings out of the route files and outermost route groups to prevent them from being affected by route caching.

Fixes #314, #315, #316, #317, #318, and #319.