### PR TITLE
Replace route model bindings with a middleware-based alternative

### DIFF
--- a/src/ForumServiceProvider.php
+++ b/src/ForumServiceProvider.php
@@ -72,10 +72,8 @@ class ForumServiceProvider extends ServiceProvider
 
     private function enableApi(Router $router)
     {
-        $router->middlewareGroup('forum:api:resolve', [ResolveApiParameters::class]);
-
         $config = config('forum.api.router');
-        $config['middleware'][] = 'forum:api:resolve';
+        $config['middleware'][] = ResolveApiParameters::class;
 
         $router
             ->prefix($config['prefix'])
@@ -89,14 +87,12 @@ class ForumServiceProvider extends ServiceProvider
 
     private function enableWeb(Router $router)
     {
-        $router->middlewareGroup('forum:web:resolve', [ResolveWebParameters::class]);
-
         $this->publishes([
             __DIR__.'/../views/' => resource_path('views/vendor/forum'),
         ], 'views');
 
         $config = config('forum.web.router');
-        $config['middleware'][] = 'forum:web:resolve';
+        $config['middleware'][] = ResolveWebParameters::class;
 
         $router
             ->prefix($config['prefix'])

--- a/src/ForumServiceProvider.php
+++ b/src/ForumServiceProvider.php
@@ -7,8 +7,6 @@ use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use TeamTeaTime\Forum\Console\Commands\Seed;

--- a/src/ForumServiceProvider.php
+++ b/src/ForumServiceProvider.php
@@ -13,9 +13,8 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use TeamTeaTime\Forum\Console\Commands\Seed;
 use TeamTeaTime\Forum\Console\Commands\SyncStats;
-use TeamTeaTime\Forum\Models\Category;
-use TeamTeaTime\Forum\Models\Post;
-use TeamTeaTime\Forum\Models\Thread;
+use TeamTeaTime\Forum\Http\Middleware\ResolveApiParameters;
+use TeamTeaTime\Forum\Http\Middleware\ResolveWebParameters;
 
 class ForumServiceProvider extends ServiceProvider
 {
@@ -41,27 +40,11 @@ class ForumServiceProvider extends ServiceProvider
         }
 
         if (config('forum.api.enable')) {
-            $router->group(config('forum.api.router'), function () {
-                $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
-            });
-
-            $this->registerApiRouteBindings();
+            $this->enableApi($router);
         }
 
         if (config('forum.web.enable')) {
-            $this->publishes([
-                __DIR__.'/../views/' => resource_path('views/vendor/forum'),
-            ], 'views');
-
-            $router->group(config('forum.web.router'), function () {
-                $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
-            });
-
-            // TODO: Make sure these don't clash with the API route bindings if both web and API are enabled.
-            // Maybe use different param names?
-            $this->registerWebRouteBindings();
-
-            $this->loadViewsFrom(__DIR__.'/../views', 'forum');
+            $this->enableWeb($router);
         }
 
         $this->loadTranslationsFrom(__DIR__.'/../translations', 'forum');
@@ -89,6 +72,46 @@ class ForumServiceProvider extends ServiceProvider
         }
     }
 
+    private function enableApi(Router $router)
+    {
+        $router->middlewareGroup('forum:api:resolve', [ResolveApiParameters::class]);
+
+        $config = config('forum.api.router');
+        $config['middleware'][] = 'forum:api:resolve';
+
+        $router
+            ->prefix($config['prefix'])
+            ->name($config['as'])
+            ->namespace($config['namespace'])
+            ->middleware($config['middleware'])
+            ->group(function () {
+                $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
+            });
+    }
+
+    private function enableWeb(Router $router)
+    {
+        $router->middlewareGroup('forum:web:resolve', [ResolveWebParameters::class]);
+
+        $this->publishes([
+            __DIR__.'/../views/' => resource_path('views/vendor/forum'),
+        ], 'views');
+
+        $config = config('forum.web.router');
+        $config['middleware'][] = 'forum:web:resolve';
+
+        $router
+            ->prefix($config['prefix'])
+            ->name($config['as'])
+            ->namespace($config['namespace'])
+            ->middleware($config['middleware'])
+            ->group(function () {
+                $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+            });
+
+        $this->loadViewsFrom(__DIR__.'/../views', 'forum');
+    }
+
     private function registerPolicies(GateContract $gate)
     {
         $forumPolicy = config('forum.integration.policies.forum');
@@ -99,71 +122,5 @@ class ForumServiceProvider extends ServiceProvider
         foreach (config('forum.integration.policies.model') as $model => $policy) {
             $gate->policy($model, $policy);
         }
-    }
-
-    private function registerApiRouteBindings()
-    {
-        Route::bind('category', function ($value) {
-            return Category::find($value);
-        });
-
-        Route::bind('thread', function ($value) {
-            $query = Thread::with('category');
-
-            if (Gate::allows('viewTrashedThreads')) {
-                $query->withTrashed();
-            }
-
-            return $query->find($value);
-        });
-
-        Route::bind('post', function ($value) {
-            $query = Post::with(['thread', 'thread.category']);
-
-            if (Gate::allows('viewTrashedPosts')) {
-                $query->withTrashed();
-            }
-
-            return $query->find($value);
-        });
-    }
-
-    private function registerWebRouteBindings()
-    {
-        Route::bind('category', function ($value) {
-            return Category::findOrFail($value);
-        });
-
-        Route::bind('thread', function ($value) {
-            $query = Thread::with('category');
-
-            if (Gate::allows('viewTrashedThreads')) {
-                $query->withTrashed();
-            }
-
-            $thread = $query->find($value);
-
-            if ($thread === null) {
-                abort(404);
-            }
-
-            return $thread;
-        });
-
-        Route::bind('post', function ($value) {
-            $query = Post::with(['thread', 'thread.category']);
-
-            if (Gate::allows('viewTrashedPosts')) {
-                $query->withTrashed();
-            }
-
-            $post = $query->find($value);
-
-            if ($post === null) {
-                abort(404);
-            }
-
-            return $post;
-        });
     }
 }

--- a/src/Http/Controllers/Web/CategoryController.php
+++ b/src/Http/Controllers/Web/CategoryController.php
@@ -29,8 +29,10 @@ class CategoryController extends BaseController
         return ViewFactory::make('forum::category.index', compact('categories'));
     }
 
-    public function show(Request $request, Category $category): View
+    public function show(Request $request): View
     {
+        $category = $request->route('category');
+
         if (! $category->isAccessibleTo($request->user())) {
             abort(404);
         }

--- a/src/Http/Controllers/Web/PostController.php
+++ b/src/Http/Controllers/Web/PostController.php
@@ -19,8 +19,10 @@ use TeamTeaTime\Forum\Support\Web\Forum;
 
 class PostController extends BaseController
 {
-    public function show(Request $request, Thread $thread, string $postSlug, Post $post): View
+    public function show(Request $request): View
     {
+        $thread = $request->route('thread');
+
         if (! $thread->category->isAccessibleTo($request->user())) {
             abort(404);
         }
@@ -30,14 +32,17 @@ class PostController extends BaseController
         }
 
         if ($request->user() !== null) {
+            $post = $request->route('post');
             UserViewingPost::dispatch($request->user(), $post);
         }
 
         return ViewFactory::make('forum::post.show', compact('thread', 'post'));
     }
 
-    public function create(Request $request, Thread $thread): View
+    public function create(Request $request): View
     {
+        $thread = $request->route('thread');
+
         $this->authorize('reply', $thread);
 
         UserCreatingPost::dispatch($request->user(), $thread);
@@ -47,8 +52,10 @@ class PostController extends BaseController
         return ViewFactory::make('forum::post.create', compact('thread', 'post'));
     }
 
-    public function store(CreatePost $request, Thread $thread): RedirectResponse
+    public function store(CreatePost $request): RedirectResponse
     {
+        $thread = $request->route('thread');
+
         $this->authorize('reply', $thread);
 
         $post = $request->fulfill();
@@ -58,8 +65,10 @@ class PostController extends BaseController
         return new RedirectResponse(Forum::route('thread.show', $post));
     }
 
-    public function edit(Request $request, Thread $thread, $threadSlug, Post $post): View
+    public function edit(Request $request): View
     {
+        $post = $request->route('post');
+
         if ($post->trashed()) {
             return abort(404);
         }
@@ -74,8 +83,10 @@ class PostController extends BaseController
         return ViewFactory::make('forum::post.edit', compact('category', 'thread', 'post'));
     }
 
-    public function update(UpdatePost $request, Thread $thread, $threadSlug, Post $post): RedirectResponse
+    public function update(UpdatePost $request): RedirectResponse
     {
+        $post = $request->route('post');
+
         $this->authorize('edit', $post);
 
         $post = $request->fulfill();
@@ -85,13 +96,19 @@ class PostController extends BaseController
         return new RedirectResponse(Forum::route('thread.show', $post));
     }
 
-    public function confirmDelete(Request $request, Thread $thread, $threadSlug, Post $post): View
+    public function confirmDelete(Request $request): View
     {
+        $thread = $request->route('thread');
+        $post = $request->route('post');
+
         return ViewFactory::make('forum::post.confirm-delete', ['category' => $thread->category, 'thread' => $thread, 'post' => $post]);
     }
 
-    public function confirmRestore(Request $request, Thread $thread, $threadSlug, Post $post): View
+    public function confirmRestore(Request $request): View
     {
+        $thread = $request->route('thread');
+        $post = $request->route('post');
+
         return ViewFactory::make('forum::post.confirm-restore', ['category' => $thread->category, 'thread' => $thread, 'post' => $post]);
     }
 

--- a/src/Http/Controllers/Web/PostController.php
+++ b/src/Http/Controllers/Web/PostController.php
@@ -13,8 +13,6 @@ use TeamTeaTime\Forum\Http\Requests\CreatePost;
 use TeamTeaTime\Forum\Http\Requests\DeletePost;
 use TeamTeaTime\Forum\Http\Requests\RestorePost;
 use TeamTeaTime\Forum\Http\Requests\UpdatePost;
-use TeamTeaTime\Forum\Models\Post;
-use TeamTeaTime\Forum\Models\Thread;
 use TeamTeaTime\Forum\Support\Web\Forum;
 
 class PostController extends BaseController

--- a/src/Http/Controllers/Web/ThreadController.php
+++ b/src/Http/Controllers/Web/ThreadController.php
@@ -81,8 +81,10 @@ class ThreadController extends BaseController
         return new RedirectResponse(Forum::route('unread'));
     }
 
-    public function show(Request $request, Thread $thread): View
+    public function show(Request $request): View
     {
+        $thread = $request->route('thread');
+
         if (! $thread->category->isAccessibleTo($request->user())) {
             abort(404);
         }
@@ -123,8 +125,10 @@ class ThreadController extends BaseController
         return ViewFactory::make('forum::thread.show', compact('categories', 'category', 'thread', 'posts', 'selectablePosts'));
     }
 
-    public function create(Request $request, Category $category): View
+    public function create(Request $request): View
     {
+        $category = $request->route('category');
+
         if (! $category->accepts_threads) {
             Forum::alert('warning', 'categories.threads_disabled');
 
@@ -138,7 +142,7 @@ class ThreadController extends BaseController
         return ViewFactory::make('forum::thread.create', compact('category'));
     }
 
-    public function store(CreateThread $request, Category $category): RedirectResponse
+    public function store(CreateThread $request): RedirectResponse
     {
         $thread = $request->fulfill();
 

--- a/src/Http/Middleware/ResolveApiParameters.php
+++ b/src/Http/Middleware/ResolveApiParameters.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace TeamTeaTime\Forum\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use TeamTeaTime\Models\Category;
+use TeamTeaTime\Models\Post;
+use TeamTeaTime\Models\Thread;
+
+class ResolveApiParameters
+{
+    /**
+     * Resolve forum API route parameters.
+     * This logic was originally applied using Route::bind, but moved here to scope it to the package routes.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $parameters = $request->route()->parameters();
+
+        if (array_key_exists('category', $parameters)) {
+            $request->route()->setParameter('category', Category::find($parameters['category']));
+        }
+
+        if (array_key_exists('thread', $parameters)) {
+            $query = Thread::with('category');
+
+            if (Gate::allows('viewTrashedThreads')) {
+                $query->withTrashed();
+            }
+
+            $request->route()->setParameter('thread', $query->find($parameters['thread']));
+        }
+
+        if (array_key_exists('post', $parameters)) {
+            $query = Post::with(['thread', 'thread.category']);
+
+            if (Gate::allows('viewTrashedPosts')) {
+                $query->withTrashed();
+            }
+
+            $request->route()->setParameter('post', $query->find($parameters['post']));
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/ResolveApiParameters.php
+++ b/src/Http/Middleware/ResolveApiParameters.php
@@ -5,7 +5,6 @@ namespace TeamTeaTime\Forum\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use TeamTeaTime\Models\Category;
 use TeamTeaTime\Models\Post;
 use TeamTeaTime\Models\Thread;

--- a/src/Http/Middleware/ResolveWebParameters.php
+++ b/src/Http/Middleware/ResolveWebParameters.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace TeamTeaTime\Forum\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use TeamTeaTime\Forum\Models\Category;
+use TeamTeaTime\Forum\Models\Post;
+use TeamTeaTime\Forum\Models\Thread;
+
+class ResolveWebParameters
+{
+    /**
+     * Resolve forum web route parameters.
+     * This logic was originally applied using Route::bind, but moved here to scope it to the package routes.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $parameters = $request->route()->parameters();
+
+        if (array_key_exists('category', $parameters)) {
+            $category = Category::find($parameters['category']);
+
+            if ($category === null) {
+                throw new NotFoundHttpException("Failed to resolve 'category' route parameter.");
+            }
+
+            $request->route()->setParameter('category', $category);
+        }
+
+        if (array_key_exists('thread', $parameters)) {
+            $query = Thread::with('category');
+
+            if (Gate::allows('viewTrashedThreads')) {
+                $query->withTrashed();
+            }
+
+            $thread = $query->find($parameters['thread']);
+
+            if ($thread === null) {
+                throw new NotFoundHttpException("Failed to resolve 'thread' route parameter.");
+            }
+
+            $request->route()->setParameter('thread', $thread);
+        }
+
+        if (array_key_exists('post', $parameters)) {
+            $query = Post::with(['thread', 'thread.category']);
+
+            if (Gate::allows('viewTrashedPosts')) {
+                $query->withTrashed();
+            }
+
+            $post = $query->find($parameters['post']);
+
+            if ($post === null) {
+                throw new NotFoundHttpException("Failed to resolve 'post' route parameter.");
+            }
+
+            $request->route()->setParameter('post', $post);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
This PR does the following:

* Removes `Route::bind` usages and moves the corresponding logic into middleware
* Updates controller actions to use `$request->route(...)` to obtain resolved models instead of using the injected parameters (which trigger implicit route model binding)
* Makes router usage more explicit by using the appropriate router methods instead of passing the config directly to the router groups

This resolves an issue whereby route model binding can conflict with other routes in the application using the same parameter names (see #321).