### PR TITLE
API routing fixes and return type fixes for PHP 8.1

### DIFF
--- a/src/Http/Controllers/Api/CategoryController.php
+++ b/src/Http/Controllers/Api/CategoryController.php
@@ -9,7 +9,6 @@ use TeamTeaTime\Forum\Http\Requests\CreateCategory;
 use TeamTeaTime\Forum\Http\Requests\DeleteCategory;
 use TeamTeaTime\Forum\Http\Requests\UpdateCategory;
 use TeamTeaTime\Forum\Http\Resources\CategoryResource;
-use TeamTeaTime\Forum\Models\Category;
 use TeamTeaTime\Forum\Support\CategoryPrivacy;
 
 class CategoryController extends BaseController
@@ -28,7 +27,7 @@ class CategoryController extends BaseController
     public function fetch(Request $request): mixed
     {
         $category = $request->route('category');
-        if (!$category->isAccessibleTo($request->user())) {
+        if (! $category->isAccessibleTo($request->user())) {
             return $this->notFoundResponse();
         }
 

--- a/src/Http/Controllers/Api/CategoryController.php
+++ b/src/Http/Controllers/Api/CategoryController.php
@@ -25,7 +25,7 @@ class CategoryController extends BaseController
         return CategoryResource::collection($categories);
     }
 
-    public function fetch(Request $request): CategoryResource|Response
+    public function fetch(Request $request): mixed
     {
         $category = $request->route('category');
         if (!$category->isAccessibleTo($request->user())) {

--- a/src/Http/Controllers/Api/CategoryController.php
+++ b/src/Http/Controllers/Api/CategoryController.php
@@ -25,9 +25,10 @@ class CategoryController extends BaseController
         return CategoryResource::collection($categories);
     }
 
-    public function fetch(Request $request, Category $category): CategoryResource
+    public function fetch(Request $request): CategoryResource|Response
     {
-        if (! $category->isAccessibleTo($request->user())) {
+        $category = $request->route('category');
+        if (!$category->isAccessibleTo($request->user())) {
             return $this->notFoundResponse();
         }
 

--- a/src/Http/Controllers/Api/PostController.php
+++ b/src/Http/Controllers/Api/PostController.php
@@ -16,7 +16,7 @@ use TeamTeaTime\Forum\Models\Thread;
 
 class PostController extends BaseController
 {
-    public function indexByThread(Request $request): AnonymousResourceCollection|Response
+    public function indexByThread(Request $request): mixed
     {
         $thread = $request->route('thread');
         if (!$thread->category->isAccessibleTo($request->user())) {
@@ -44,8 +44,7 @@ class PostController extends BaseController
             ->filter(function (Post $post) use ($request, $unreadOnly) {
                 return $post->thread->category->isAccessibleTo($request->user())
                     && (!$unreadOnly || $post->thread->reader === null || $post->updatedSince($post->thread->reader))
-                    && (
-                        ! $post->thread->category->is_private
+                    && (!$post->thread->category->is_private
                         || $request->user()
                         && $request->user()->can('view', $post->thread)
                     );
@@ -59,7 +58,7 @@ class PostController extends BaseController
         return $this->recent($request, true);
     }
 
-    public function fetch(Request $request): PostResource|Response
+    public function fetch(Request $request): mixed
     {
         $post = $request->route('post');
         if (!$post->thread->category->isAccessibleTo($request->user())) {

--- a/src/Http/Controllers/Api/PostController.php
+++ b/src/Http/Controllers/Api/PostController.php
@@ -12,14 +12,13 @@ use TeamTeaTime\Forum\Http\Requests\SearchPosts;
 use TeamTeaTime\Forum\Http\Requests\UpdatePost;
 use TeamTeaTime\Forum\Http\Resources\PostResource;
 use TeamTeaTime\Forum\Models\Post;
-use TeamTeaTime\Forum\Models\Thread;
 
 class PostController extends BaseController
 {
     public function indexByThread(Request $request): mixed
     {
         $thread = $request->route('thread');
-        if (!$thread->category->isAccessibleTo($request->user())) {
+        if (! $thread->category->isAccessibleTo($request->user())) {
             return $this->notFoundResponse();
         }
 
@@ -43,8 +42,8 @@ class PostController extends BaseController
             ->get()
             ->filter(function (Post $post) use ($request, $unreadOnly) {
                 return $post->thread->category->isAccessibleTo($request->user())
-                    && (!$unreadOnly || $post->thread->reader === null || $post->updatedSince($post->thread->reader))
-                    && (!$post->thread->category->is_private
+                    && (! $unreadOnly || $post->thread->reader === null || $post->updatedSince($post->thread->reader))
+                    && (! $post->thread->category->is_private
                         || $request->user()
                         && $request->user()->can('view', $post->thread)
                     );
@@ -61,7 +60,7 @@ class PostController extends BaseController
     public function fetch(Request $request): mixed
     {
         $post = $request->route('post');
-        if (!$post->thread->category->isAccessibleTo($request->user())) {
+        if (! $post->thread->category->isAccessibleTo($request->user())) {
             return $this->notFoundResponse();
         }
 

--- a/src/Http/Controllers/Api/PostController.php
+++ b/src/Http/Controllers/Api/PostController.php
@@ -16,9 +16,10 @@ use TeamTeaTime\Forum\Models\Thread;
 
 class PostController extends BaseController
 {
-    public function indexByThread(Thread $thread, Request $request): AnonymousResourceCollection
+    public function indexByThread(Request $request): AnonymousResourceCollection|Response
     {
-        if (! $thread->category->isAccessibleTo($request->user())) {
+        $thread = $request->route('thread');
+        if (!$thread->category->isAccessibleTo($request->user())) {
             return $this->notFoundResponse();
         }
 
@@ -42,7 +43,7 @@ class PostController extends BaseController
             ->get()
             ->filter(function (Post $post) use ($request, $unreadOnly) {
                 return $post->thread->category->isAccessibleTo($request->user())
-                    && (! $unreadOnly || $post->thread->reader === null || $post->updatedSince($post->thread->reader))
+                    && (!$unreadOnly || $post->thread->reader === null || $post->updatedSince($post->thread->reader))
                     && (
                         ! $post->thread->category->is_private
                         || $request->user()
@@ -58,9 +59,10 @@ class PostController extends BaseController
         return $this->recent($request, true);
     }
 
-    public function fetch(Post $post, Request $request): PostResource
+    public function fetch(Request $request): PostResource|Response
     {
-        if (! $post->thread->category->isAccessibleTo($request->user())) {
+        $post = $request->route('post');
+        if (!$post->thread->category->isAccessibleTo($request->user())) {
             return $this->notFoundResponse();
         }
 

--- a/src/Http/Controllers/Api/ThreadController.php
+++ b/src/Http/Controllers/Api/ThreadController.php
@@ -29,8 +29,7 @@ class ThreadController extends BaseController
             ->filter(function ($thread) use ($request, $unreadOnly) {
                 return $thread->category->isAccessibleTo($request->user())
                     && (!$unreadOnly || $thread->userReadStatus !== null)
-                    && (
-                        ! $thread->category->is_private
+                    && (!$thread->category->is_private
                         || $request->user()
                         && $request->user()->can('view', $thread)
                     );
@@ -51,7 +50,7 @@ class ThreadController extends BaseController
         return new Response(['success' => true]);
     }
 
-    public function indexByCategory(Request $request): AnonymousResourceCollection|Response
+    public function indexByCategory(Request $request): mixed
     {
         $category = $request->route('category');
         if (!$category->isAccessibleTo($request->user())) {
@@ -96,7 +95,7 @@ class ThreadController extends BaseController
         return new ThreadResource($thread);
     }
 
-    public function fetch(Request $request): ThreadResource|Response
+    public function fetch(Request $request): mixed
     {
         $thread = $request->route('thread');
         if (!$thread->category->isAccessibleTo($request->user())) {

--- a/src/Http/Controllers/Api/ThreadController.php
+++ b/src/Http/Controllers/Api/ThreadController.php
@@ -28,7 +28,7 @@ class ThreadController extends BaseController
             ->get()
             ->filter(function ($thread) use ($request, $unreadOnly) {
                 return $thread->category->isAccessibleTo($request->user())
-                    && (! $unreadOnly || $thread->userReadStatus !== null)
+                    && (!$unreadOnly || $thread->userReadStatus !== null)
                     && (
                         ! $thread->category->is_private
                         || $request->user()
@@ -51,9 +51,10 @@ class ThreadController extends BaseController
         return new Response(['success' => true]);
     }
 
-    public function indexByCategory(Request $request, Category $category): AnonymousResourceCollection
+    public function indexByCategory(Request $request): AnonymousResourceCollection|Response
     {
-        if (! $category->isAccessibleTo($request->user())) {
+        $category = $request->route('category');
+        if (!$category->isAccessibleTo($request->user())) {
             return $this->notFoundResponse();
         }
 
@@ -95,9 +96,10 @@ class ThreadController extends BaseController
         return new ThreadResource($thread);
     }
 
-    public function fetch(Request $request, Thread $thread): ThreadResource
+    public function fetch(Request $request): ThreadResource|Response
     {
-        if (! $thread->category->isAccessibleTo($request->user())) {
+        $thread = $request->route('thread');
+        if (!$thread->category->isAccessibleTo($request->user())) {
             return $this->notFoundResponse();
         }
 
@@ -152,7 +154,7 @@ class ThreadController extends BaseController
         return new Response(new ThreadResource($thread));
     }
 
-    public function rename(RenameThread $request): ThreadResource
+    public function rename(RenameThread $request): Response
     {
         $thread = $request->fulfill();
 

--- a/src/Http/Controllers/Api/ThreadController.php
+++ b/src/Http/Controllers/Api/ThreadController.php
@@ -17,7 +17,6 @@ use TeamTeaTime\Forum\Http\Requests\RestoreThread;
 use TeamTeaTime\Forum\Http\Requests\UnlockThread;
 use TeamTeaTime\Forum\Http\Requests\UnpinThread;
 use TeamTeaTime\Forum\Http\Resources\ThreadResource;
-use TeamTeaTime\Forum\Models\Category;
 use TeamTeaTime\Forum\Models\Thread;
 
 class ThreadController extends BaseController
@@ -28,8 +27,8 @@ class ThreadController extends BaseController
             ->get()
             ->filter(function ($thread) use ($request, $unreadOnly) {
                 return $thread->category->isAccessibleTo($request->user())
-                    && (!$unreadOnly || $thread->userReadStatus !== null)
-                    && (!$thread->category->is_private
+                    && (! $unreadOnly || $thread->userReadStatus !== null)
+                    && (! $thread->category->is_private
                         || $request->user()
                         && $request->user()->can('view', $thread)
                     );
@@ -53,7 +52,7 @@ class ThreadController extends BaseController
     public function indexByCategory(Request $request): mixed
     {
         $category = $request->route('category');
-        if (!$category->isAccessibleTo($request->user())) {
+        if (! $category->isAccessibleTo($request->user())) {
             return $this->notFoundResponse();
         }
 
@@ -98,7 +97,7 @@ class ThreadController extends BaseController
     public function fetch(Request $request): mixed
     {
         $thread = $request->route('thread');
-        if (!$thread->category->isAccessibleTo($request->user())) {
+        if (! $thread->category->isAccessibleTo($request->user())) {
             return $this->notFoundResponse();
         }
 


### PR DESCRIPTION
A few of the API controller return types are incorrect if notFoundResponse is called. This breaks the code on PHP 8.1.
I've updated these methods to add |Response to the return type to fix this.

Also I'm not sure why but the method parameters for Category, Thread, and Post aren't resolving properly. I got an empty object with no fields set, and this was in turn breaking CategoryPrivacy because $this->id was null on Category line 93. Changing these all to use $request->route fixes this issue, but I'm not 100% sure what the original problem was..?