### PR TITLE
Add support for auth_middleware to API to match web functionality

### DIFF
--- a/config/api.php
+++ b/config/api.php
@@ -38,6 +38,7 @@ return [
         'as' => 'forum.api.',
         'namespace' => '\TeamTeaTime\Forum\Http\Controllers\Api',
         'middleware' => ['api', 'auth:api'],
+        'auth_middleware' => ['auth:api'],
     ],
 
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,40 +1,48 @@
 <?php
 
+$authMiddleware = config('forum.api.router.auth_middleware', []);
+
 // Categories
-Route::group(['prefix' => 'category', 'as' => 'category.'], function () {
+Route::group(['prefix' => 'category', 'as' => 'category.'], function () use ($authMiddleware) {
     Route::get('/', ['as' => 'index', 'uses' => 'CategoryController@index']);
     Route::get('{category}', ['as' => 'fetch', 'uses' => 'CategoryController@fetch']);
-    Route::post('/', ['as' => 'store', 'uses' => 'CategoryController@store']);
-    Route::patch('{category}', ['as' => 'update', 'uses' => 'CategoryController@update']);
-    Route::delete('{category}', ['as' => 'delete', 'uses' => 'CategoryController@delete']);
+
+    Route::group(['middleware' => $authMiddleware], function () {
+        Route::post('/', ['as' => 'store', 'uses' => 'CategoryController@store']);
+        Route::patch('{category}', ['as' => 'update', 'uses' => 'CategoryController@update']);
+        Route::delete('{category}', ['as' => 'delete', 'uses' => 'CategoryController@delete']);
+    });
 
     // Threads by category
     Route::get('{category}/thread', ['as' => 'threads', 'uses' => 'ThreadController@indexByCategory']);
-    Route::post('{category}/thread', ['as' => 'threads.store', 'uses' => 'ThreadController@store']);
+    Route::post('{category}/thread', ['as' => 'threads.store', 'uses' => 'ThreadController@store'])->middleware($authMiddleware);
 });
 
 // Threads
-Route::group(['prefix' => 'thread', 'as' => 'thread.'], function () {
+Route::group(['prefix' => 'thread', 'as' => 'thread.'], function () use ($authMiddleware) {
     Route::get('recent', ['as' => 'recent', 'uses' => 'ThreadController@recent']);
     Route::get('unread', ['as' => 'unread', 'uses' => 'ThreadController@unread']);
-    Route::patch('unread/mark-as-read', ['as' => 'unread.mark-as-read', 'uses' => 'ThreadController@markAsRead']);
+    Route::patch('unread/mark-as-read', ['as' => 'unread.mark-as-read', 'uses' => 'ThreadController@markAsRead'])->middleware($authMiddleware);
     Route::get('{thread}', ['as' => 'fetch', 'uses' => 'ThreadController@fetch']);
-    Route::post('{thread}/lock', ['as' => 'lock', 'uses' => 'ThreadController@lock']);
-    Route::post('{thread}/unlock', ['as' => 'unlock', 'uses' => 'ThreadController@unlock']);
-    Route::post('{thread}/pin', ['as' => 'pin', 'uses' => 'ThreadController@pin']);
-    Route::post('{thread}/unpin', ['as' => 'unpin', 'uses' => 'ThreadController@unpin']);
-    Route::post('{thread}/rename', ['as' => 'rename', 'uses' => 'ThreadController@rename']);
-    Route::post('{thread}/move', ['as' => 'move', 'uses' => 'ThreadController@move']);
-    Route::delete('{thread}', ['as' => 'delete', 'uses' => 'ThreadController@delete']);
-    Route::post('{thread}/restore', ['as' => 'restore', 'uses' => 'ThreadController@restore']);
+
+    Route::group(['middleware' => $authMiddleware], function () {
+        Route::post('{thread}/lock', ['as' => 'lock', 'uses' => 'ThreadController@lock']);
+        Route::post('{thread}/unlock', ['as' => 'unlock', 'uses' => 'ThreadController@unlock']);
+        Route::post('{thread}/pin', ['as' => 'pin', 'uses' => 'ThreadController@pin']);
+        Route::post('{thread}/unpin', ['as' => 'unpin', 'uses' => 'ThreadController@unpin']);
+        Route::post('{thread}/rename', ['as' => 'rename', 'uses' => 'ThreadController@rename']);
+        Route::post('{thread}/move', ['as' => 'move', 'uses' => 'ThreadController@move']);
+        Route::delete('{thread}', ['as' => 'delete', 'uses' => 'ThreadController@delete']);
+        Route::post('{thread}/restore', ['as' => 'restore', 'uses' => 'ThreadController@restore']);
+    });
 
     // Posts by thread
     Route::get('{thread}/posts', ['as' => 'posts', 'uses' => 'PostController@indexByThread']);
-    Route::post('{thread}/posts', ['as' => 'posts.store', 'uses' => 'PostController@store']);
+    Route::post('{thread}/posts', ['as' => 'posts.store', 'uses' => 'PostController@store'])->middleware($authMiddleware);
 });
 
 // Posts
-Route::group(['prefix' => 'post', 'as' => 'post.'], function () {
+Route::group(['prefix' => 'post', 'as' => 'post.'], function () use ($authMiddleware) {
     if (config('forum.api.enable_search')) {
         Route::post('search', ['as' => 'search', 'uses' => 'PostController@search']);
     }
@@ -42,13 +50,15 @@ Route::group(['prefix' => 'post', 'as' => 'post.'], function () {
     Route::get('recent', ['as' => 'recent', 'uses' => 'PostController@recent']);
     Route::get('unread', ['as' => 'unread', 'uses' => 'PostController@unread']);
     Route::get('{post}', ['as' => 'fetch', 'uses' => 'PostController@fetch']);
-    Route::patch('{post}', ['as' => 'update', 'uses' => 'PostController@update']);
-    Route::delete('{post}', ['as' => 'delete', 'uses' => 'PostController@delete']);
-    Route::post('{post}/restore', ['as' => 'restore', 'uses' => 'PostController@restore']);
+    Route::group(['middleware' => $authMiddleware], function () {
+        Route::patch('{post}', ['as' => 'update', 'uses' => 'PostController@update']);
+        Route::delete('{post}', ['as' => 'delete', 'uses' => 'PostController@delete']);
+        Route::post('{post}/restore', ['as' => 'restore', 'uses' => 'PostController@restore']);
+    });
 });
 
 // Bulk actions
-Route::group(['prefix' => 'bulk', 'as' => 'bulk.', 'namespace' => 'Bulk'], function () {
+Route::group(['prefix' => 'bulk', 'as' => 'bulk.', 'namespace' => 'Bulk', 'middleware' => $authMiddleware], function () {
     // Categories
     Route::group(['prefix' => 'category', 'as' => 'category.'], function () {
         Route::post('manage', ['as' => 'manage', 'uses' => 'CategoryController@manage']);


### PR DESCRIPTION
This commit adds support for public API calls in the same way as the web frontend works. This is configurable by a simple setting in config/forum.api.php and the default acts identically to the existing functionality.

The reasoning here is allowing public read-only API access to the same data that is potentially accessibly via the web frontend - such as categories, thread reading etc.

How it works:
- add a 'auth_middleware' setting to the config/forum.api.php 'router' block.
- in routes/api.php, read this and apply it to all of the calls that match the 'public' (non-authMiddleware'd) calls from routes/web.php.

To enable public API calls it's a simple matter of removing `'auth:api'` from the `'middleware'` field in config/forum.api.php, and adding an `'auth_middleware'` field with the `'auth:api'` guard (if necessary).

`'middleware' => ['api'],
'auth_middleware' => ['auth:api'],`

the publishable config file has been updated to add the `'auth_middleware'` field, but leaving `'auth:api'` in the `'middleware'` field in order to mimic current behaviour where all API calls need the same authentication.