### PR TITLE
Allow custom resource classes

### DIFF
--- a/config/api.php
+++ b/config/api.php
@@ -26,6 +26,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Resources
+    |--------------------------------------------------------------------------
+    |
+    | Override to return your own resources for API responses
+    |
+    */
+
+    'resources' => [
+        'category' => TeamTeaTime\Forum\Http\Resources\CategoryResource::class,
+        'thread' => TeamTeaTime\Forum\Http\Resources\ThreadResource::class,
+        'post' => TeamTeaTime\Forum\Http\Resources\PostResource::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Router
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Controllers/Api/CategoryController.php
+++ b/src/Http/Controllers/Api/CategoryController.php
@@ -3,8 +3,8 @@
 namespace TeamTeaTime\Forum\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
-use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Response;
 use TeamTeaTime\Forum\Http\Requests\CreateCategory;
 use TeamTeaTime\Forum\Http\Requests\DeleteCategory;

--- a/src/Http/Controllers/Api/CategoryController.php
+++ b/src/Http/Controllers/Api/CategoryController.php
@@ -3,6 +3,7 @@
 namespace TeamTeaTime\Forum\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use TeamTeaTime\Forum\Http\Requests\CreateCategory;
@@ -13,6 +14,13 @@ use TeamTeaTime\Forum\Support\CategoryPrivacy;
 
 class CategoryController extends BaseController
 {
+    protected $resourceClass = null;
+
+    public function __construct()
+    {
+        $this->resourceClass = config('forum.api.resources.category', CategoryResource::class);
+    }
+
     public function index(Request $request): AnonymousResourceCollection
     {
         if ($request->has('parent_id')) {
@@ -21,31 +29,31 @@ class CategoryController extends BaseController
             $categories = CategoryPrivacy::getFilteredFor($request->user());
         }
 
-        return CategoryResource::collection($categories);
+        return $this->resourceClass::collection($categories);
     }
 
-    public function fetch(Request $request): CategoryResource|Response
+    public function fetch(Request $request): JsonResource|Response
     {
         $category = $request->route('category');
         if (! $category->isAccessibleTo($request->user())) {
             return $this->notFoundResponse();
         }
 
-        return new CategoryResource($category);
+        return new $this->resourceClass($category);
     }
 
-    public function store(CreateCategory $request): CategoryResource
+    public function store(CreateCategory $request): JsonResource
     {
         $category = $request->fulfill();
 
-        return new CategoryResource($category);
+        return new $this->resourceClass($category);
     }
 
-    public function update(UpdateCategory $request): CategoryResource
+    public function update(UpdateCategory $request): JsonResource
     {
         $category = $request->fulfill();
 
-        return new CategoryResource($category);
+        return new $this->resourceClass($category);
     }
 
     public function delete(DeleteCategory $request): Response

--- a/src/Http/Controllers/Api/ThreadController.php
+++ b/src/Http/Controllers/Api/ThreadController.php
@@ -5,6 +5,7 @@ namespace TeamTeaTime\Forum\Http\Controllers\Api;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Response;
 use TeamTeaTime\Forum\Http\Requests\CreateThread;
 use TeamTeaTime\Forum\Http\Requests\DeleteThread;
@@ -21,6 +22,13 @@ use TeamTeaTime\Forum\Models\Thread;
 
 class ThreadController extends BaseController
 {
+    protected $resourceClass = null;
+
+    public function __construct()
+    {
+        $this->resourceClass = config('forum.api.resources.thread', ThreadResource::class);
+    }
+
     public function recent(Request $request, bool $unreadOnly = false): AnonymousResourceCollection
     {
         $threads = Thread::recent()
@@ -35,7 +43,7 @@ class ThreadController extends BaseController
                     );
             });
 
-        return ThreadResource::collection($threads);
+        return $this->resourceClass::collection($threads);
     }
 
     public function unread(Request $request): AnonymousResourceCollection
@@ -85,17 +93,17 @@ class ThreadController extends BaseController
             }));
         }
 
-        return ThreadResource::collection($threads);
+        return $this->resourceClass::collection($threads);
     }
 
-    public function store(CreateThread $request): ThreadResource
+    public function store(CreateThread $request): JsonResource
     {
         $thread = $request->fulfill();
 
-        return new ThreadResource($thread);
+        return new $this->resourceClass($thread);
     }
 
-    public function fetch(Request $request): ThreadResource|Response
+    public function fetch(Request $request): JsonResource|Response
     {
         $thread = $request->route('thread');
         if (! $thread->category->isAccessibleTo($request->user())) {
@@ -106,10 +114,10 @@ class ThreadController extends BaseController
             $this->authorize('view', $thread);
         }
 
-        return new ThreadResource($thread);
+        return new $this->resourceClass($thread);
     }
 
-    public function lock(LockThread $request): ThreadResource|Response
+    public function lock(LockThread $request): JsonResource|Response
     {
         $thread = $request->fulfill();
 
@@ -117,10 +125,10 @@ class ThreadController extends BaseController
             return $this->invalidSelectionResponse();
         }
 
-        return new ThreadResource($thread);
+        return new $this->resourceClass($thread);
     }
 
-    public function unlock(UnlockThread $request): ThreadResource|Response
+    public function unlock(UnlockThread $request): JsonResource|Response
     {
         $thread = $request->fulfill();
 
@@ -128,10 +136,10 @@ class ThreadController extends BaseController
             return $this->invalidSelectionResponse();
         }
 
-        return new ThreadResource($thread);
+        return new $this->resourceClass($thread);
     }
 
-    public function pin(PinThread $request): ThreadResource|Response
+    public function pin(PinThread $request): JsonResource|Response
     {
         $thread = $request->fulfill();
 
@@ -139,10 +147,10 @@ class ThreadController extends BaseController
             return $this->invalidSelectionResponse();
         }
 
-        return new ThreadResource($thread);
+        return new $this->resourceClass($thread);
     }
 
-    public function unpin(UnpinThread $request): ThreadResource|Response
+    public function unpin(UnpinThread $request): JsonResource|Response
     {
         $thread = $request->fulfill();
 
@@ -150,28 +158,17 @@ class ThreadController extends BaseController
             return $this->invalidSelectionResponse();
         }
 
-        return new ThreadResource($thread);
+        return new $this->resourceClass($thread);
     }
 
-    public function rename(RenameThread $request): ThreadResource
+    public function rename(RenameThread $request): JsonResource
     {
         $thread = $request->fulfill();
 
-        return new ThreadResource($thread);
+        return new $this->resourceClass($thread);
     }
 
-    public function move(MoveThread $request): ThreadResource|Response
-    {
-        $thread = $request->fulfill();
-
-        if ($thread === null) {
-            return $this->invalidSelectionResponse();
-        }
-
-        return new ThreadResource($thread);
-    }
-
-    public function delete(DeleteThread $request): ThreadResource|Response
+    public function move(MoveThread $request): JsonResource|Response
     {
         $thread = $request->fulfill();
 
@@ -179,10 +176,10 @@ class ThreadController extends BaseController
             return $this->invalidSelectionResponse();
         }
 
-        return new ThreadResource($thread);
+        return new $this->resourceClass($thread);
     }
 
-    public function restore(RestoreThread $request): ThreadResource|Response
+    public function delete(DeleteThread $request): JsonResource|Response
     {
         $thread = $request->fulfill();
 
@@ -190,6 +187,17 @@ class ThreadController extends BaseController
             return $this->invalidSelectionResponse();
         }
 
-        return new ThreadResource($thread);
+        return new $this->resourceClass($thread);
+    }
+
+    public function restore(RestoreThread $request): JsonResource|Response
+    {
+        $thread = $request->fulfill();
+
+        if ($thread === null) {
+            return $this->invalidSelectionResponse();
+        }
+
+        return new $this->resourceClass($thread);
     }
 }

--- a/src/Http/Resources/PostResource.php
+++ b/src/Http/Resources/PostResource.php
@@ -17,6 +17,7 @@ class PostResource extends JsonResource
             'id' => $this->id,
             'thread_id' => $this->thread_id,
             'author_id' => $this->author_id,
+            'author_name' => $this->author_name,
             'content' => $this->content,
             'post_id' => $this->post_id,
             'sequence' => $this->sequence,

--- a/src/Http/Resources/ThreadResource.php
+++ b/src/Http/Resources/ThreadResource.php
@@ -17,6 +17,7 @@ class ThreadResource extends JsonResource
             'id' => $this->id,
             'category_id' => $this->category_id,
             'author_id' => $this->author_id,
+            'author_name' => $this->author_name,
             'title' => $this->title,
             'pinned' => $this->pinned == 1,
             'locked' => $this->locked == 1,


### PR DESCRIPTION
This commit allows configuration of the resource classes used for category, thread, and post in the API responses. For example, one might want to return the author's name or avatar with each post.

The only requirement is the resource classes extend JsonResource which I think is sensible but it's up to you if you want to change it - it could just return a Response if you want to relax the return types in the controller methods.

It's fully backwards compatible because of to the __construct methods in the 3 controller classes. I'm not sure if you want to do this somehow differently - it's there to support users with a config file who don't have the resources => [ ... ] section.

Let me know if you have any questions or comments please