### PR TITLE
Add support for user tables with string-based PKs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /var/cache/composer
 /vendor
 .phpunit.result.cache
+.phpunit.cache

--- a/database/migrations/2014_05_19_152425_create_forum_table_threads.php
+++ b/database/migrations/2014_05_19_152425_create_forum_table_threads.php
@@ -15,7 +15,7 @@ class CreateForumTableThreads extends Migration
         Schema::create('forum_threads', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('parent_category')->unsigned();
-            $table->integer('author_id')->unsigned();
+            $table->foreignIdFor(config('forum.integration.user_model'), 'user_id');
             $table->string('title');
             $table->boolean('pinned');
             $table->boolean('locked');

--- a/database/migrations/2014_05_19_152425_create_forum_table_threads.php
+++ b/database/migrations/2014_05_19_152425_create_forum_table_threads.php
@@ -15,7 +15,7 @@ class CreateForumTableThreads extends Migration
         Schema::create('forum_threads', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('parent_category')->unsigned();
-            $table->foreignIdFor(config('forum.integration.user_model'), 'user_id');
+            $table->foreignIdFor(config('forum.integration.user_model'), 'author_id');
             $table->string('title');
             $table->boolean('pinned');
             $table->boolean('locked');

--- a/database/migrations/2014_05_19_152611_create_forum_table_posts.php
+++ b/database/migrations/2014_05_19_152611_create_forum_table_posts.php
@@ -15,7 +15,7 @@ class CreateForumTablePosts extends Migration
         Schema::create('forum_posts', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('parent_thread')->unsigned();
-            $table->integer('author_id')->unsigned();
+            $table->foreignIdFor(config('forum.integration.user_model'), 'user_id');
             $table->text('content');
 
             $table->timestamps();

--- a/database/migrations/2014_05_19_152611_create_forum_table_posts.php
+++ b/database/migrations/2014_05_19_152611_create_forum_table_posts.php
@@ -15,7 +15,7 @@ class CreateForumTablePosts extends Migration
         Schema::create('forum_posts', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('parent_thread')->unsigned();
-            $table->foreignIdFor(config('forum.integration.user_model'), 'user_id');
+            $table->foreignIdFor(config('forum.integration.user_model'), 'author_id');
             $table->text('content');
 
             $table->timestamps();

--- a/database/migrations/2015_04_14_180344_create_forum_table_threads_read.php
+++ b/database/migrations/2015_04_14_180344_create_forum_table_threads_read.php
@@ -14,7 +14,7 @@ class CreateForumTableThreadsRead extends Migration
     {
         Schema::create('forum_threads_read', function (Blueprint $table) {
             $table->integer('thread_id')->unsigned();
-            $table->integer('user_id')->unsigned();
+            $table->foreignIdFor(config('forum.integration.user_model'), 'user_id');
             $table->timestamps();
         });
     }

--- a/src/Actions/MarkThreadsAsRead.php
+++ b/src/Actions/MarkThreadsAsRead.php
@@ -35,7 +35,7 @@ class MarkThreadsAsRead extends BaseAction
         });
 
         foreach ($threads as $thread) {
-            $thread->markAsRead($this->user->getKey());
+            $thread->markAsRead($this->user);
         }
 
         return $threads;

--- a/src/Http/Controllers/Web/ThreadController.php
+++ b/src/Http/Controllers/Web/ThreadController.php
@@ -95,7 +95,7 @@ class ThreadController extends BaseController
 
         if ($request->user() !== null) {
             UserViewingThread::dispatch($request->user(), $thread);
-            $thread->markAsRead($request->user()->getKey());
+            $thread->markAsRead($request->user());
         }
 
         $category = $thread->category;

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -3,6 +3,7 @@
 namespace TeamTeaTime\Forum\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -124,14 +125,14 @@ class Thread extends BaseModel
         return $this->posts()->orderBy('created_at', 'desc')->first();
     }
 
-    public function markAsRead(int $userId): void
+    public function markAsRead(Model $user): void
     {
         if ($this->isOld) {
             return;
         }
 
         if ($this->reader === null) {
-            $this->readers()->attach($userId);
+            $this->readers()->attach($user->getKey());
         } elseif ($this->updatedSince($this->reader)) {
             $this->reader->touch();
         }

--- a/src/Tests/FeatureTestCase.php
+++ b/src/Tests/FeatureTestCase.php
@@ -2,16 +2,12 @@
 
 namespace TeamTeaTime\Forum\Tests;
 
-use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Route;
 
 class FeatureTestCase extends TestCase
 {
     protected function setUp(): void
     {
-        // Override user model in config
-        config(['forum.integration.user_model' => User::class]);
-
         parent::setUp();
 
         // Create dummy login route for the default redirection

--- a/src/Tests/FeatureTestCase.php
+++ b/src/Tests/FeatureTestCase.php
@@ -9,14 +9,14 @@ class FeatureTestCase extends TestCase
 {
     protected function setUp(): void
     {
+        // Override user model in config
+        config(['forum.integration.user_model' => User::class]);
+
         parent::setUp();
 
         // Create dummy login route for the default redirection
         Route::get('login', ['as' => 'login'], function () {
             return '';
         });
-
-        // Override user model in config
-        config(['forum.integration.user_model' => User::class]);
     }
 }

--- a/src/Tests/TestCase.php
+++ b/src/Tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace TeamTeaTime\Forum\Tests;
 
+use Illuminate\Foundation\Auth\User;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class TestCase extends \Orchestra\Testbench\TestCase
@@ -11,6 +12,9 @@ class TestCase extends \Orchestra\Testbench\TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        // Override user model in config
+        config(['forum.integration.user_model' => User::class]);
 
         $this->loadLaravelMigrations();
         $this->loadMigrationsFrom(__DIR__.'/../../database/migrations');


### PR DESCRIPTION
This PR enables the package tables and models to reference the application user correctly by matching the user table's primary key type.

See #356 for related discussion.