### PR TITLE
Fix outdated action reference

### DIFF
--- a/src/Http/Requests/EditCategory.php
+++ b/src/Http/Requests/EditCategory.php
@@ -3,7 +3,7 @@
 namespace TeamTeaTime\Forum\Http\Requests;
 
 use TeamTeaTime\Forum\{
-    Actions\UpdateCategory as Action,
+    Actions\EditCategory as Action,
     Events\UserEditedCategory,
 };
 


### PR DESCRIPTION
Fixes a usage of the UpdateCategory action, which was renamed to EditCategory for 6.0.