### PR TITLE
[5.x] Use index for sequence number on DeletePost action

### DIFF
--- a/src/Actions/DeletePost.php
+++ b/src/Actions/DeletePost.php
@@ -47,8 +47,8 @@ class DeletePost extends BaseAction
         }
 
         // Update sequence numbers for all of the thread's posts
-        $this->post->thread->posts->each(function ($p) {
-            $p->updateWithoutTouch(['sequence' => $p->getSequenceNumber()]);
+        $this->post->thread->posts->each(function ($p, $i) {
+            $p->updateWithoutTouch(['sequence' => $i + 1]);
         });
 
         return $this->post;


### PR DESCRIPTION
Using the loop index instead of calling `getSequenceNumber` method on `Post` model for better performance.

As discussed here https://github.com/Team-Tea-Time/laravel-forum/discussions/376