### PR TITLE
[5.x] Use index for sequence number on DeletePosts action

### DIFF
--- a/src/Actions/Bulk/DeletePosts.php
+++ b/src/Actions/Bulk/DeletePosts.php
@@ -83,8 +83,8 @@ class DeletePosts extends BaseAction
                         'reply_count' => DB::raw("reply_count - {$threadPostsRemoved}"),
                     ]);
 
-                    $thread->posts->each(function ($p) {
-                        $p->updateWithoutTouch(['sequence' => $p->getSequenceNumber()]);
+                    $thread->posts->each(function ($p, $i) {
+                        $p->updateWithoutTouch(['sequence' => $i + 1]);
                     });
                 }
             }

--- a/src/Actions/DeletePost.php
+++ b/src/Actions/DeletePost.php
@@ -47,8 +47,8 @@ class DeletePost extends BaseAction
         }
 
         // Update sequence numbers for all of the thread's posts
-        $this->post->thread->posts->each(function ($p) {
-            $p->updateWithoutTouch(['sequence' => $p->getSequenceNumber()]);
+        $this->post->thread->posts->each(function ($p, $i) {
+            $p->updateWithoutTouch(['sequence' => $i + 1]);
         });
 
         return $this->post;


### PR DESCRIPTION
Using the same method as done at #377 for updating sequence number, preventing timeouts on threads with a lot of posts.

