### PR TITLE
Fix post sequences

### DIFF
--- a/src/Actions/Bulk/DeletePosts.php
+++ b/src/Actions/Bulk/DeletePosts.php
@@ -83,7 +83,7 @@ class DeletePosts extends BaseAction
                         'reply_count' => DB::raw("reply_count - {$threadPostsRemoved}"),
                     ]);
 
-                    $thread->posts->each(function ($p, $i) {
+                    $thread->posts()->withTrashed()->each(function ($p, $i) {
                         $p->updateWithoutTouch(['sequence' => $i + 1]);
                     });
                 }

--- a/src/Actions/DeletePost.php
+++ b/src/Actions/DeletePost.php
@@ -47,7 +47,7 @@ class DeletePost extends BaseAction
         }
 
         // Update sequence numbers for all of the thread's posts
-        $this->post->thread->posts->each(function ($p, $i) {
+        $this->post->thread->posts()->withTrashed()->each(function ($p, $i) {
             $p->updateWithoutTouch(['sequence' => $i + 1]);
         });
 

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -55,28 +55,15 @@ class Post extends BaseModel
         return $query->where('updated_at', '>', date('Y-m-d H:i:s', $cutoff))->orderBy('updated_at', 'desc');
     }
 
-    public function getSequenceNumber(bool $withTrashed = false): int
-    {
-        $posts = $withTrashed
-            ? $this->thread->posts()->withTrashed()->get()
-            : $this->thread->posts;
-
-        foreach ($posts as $index => $post) {
-            if ($post->id == $this->id) {
-                return $index + 1;
-            }
-        }
-    }
-
     public function getPage(): int
     {
-        return ceil($this->getSequenceNumber(true) / $this->getPerPage());
+        return ceil($this->sequence / $this->getPerPage());
     }
 
     protected function route(): Attribute
     {
         return new Attribute(
-            get: fn () => Forum::route('thread.show', $this),
+            get: fn() => Forum::route('thread.show', $this),
         );
     }
 }


### PR DESCRIPTION
Removes `Post::getSequenceNumber` and ensures sequence updates include trashed posts.