### PR TITLE
Improve preset installer clarity

### DIFF
--- a/src/Console/Commands/PresetInstall.php
+++ b/src/Console/Commands/PresetInstall.php
@@ -9,11 +9,13 @@ use TeamTeaTime\Forum\Frontend\Presets\AbstractPreset;
 use TeamTeaTime\Forum\Frontend\Presets\PresetRegistry;
 
 use function Laravel\Prompts\{
+    alert,
     confirm,
     error,
     info,
     note,
     select,
+    warning,
 };
 
 class PresetInstall extends Command implements PromptsForMissingInput
@@ -77,21 +79,38 @@ class PresetInstall extends Command implements PromptsForMissingInput
 
         $preset->publish($filesystem);
 
-        info("Preset '{$name}' has been copied to your application's resource directory.");
+        info("Done! Preset '{$name}' has been copied to your application's resource directory.");
+
+        alert("IMPORTANT: Please read the info below as it details manual steps required for the preset to work!");
 
         $requiredPackages = $preset->getRequiredPackages();
 
         if (count($requiredPackages) > 0) {
             info("This preset requires the following NPM packages:");
             foreach ($requiredPackages as $package) {
-                $this->line("  $package");
+                $this->line("    $package");
             }
 
             info("You can install them with:");
             note("npm i " . implode(' ', $requiredPackages));
+
+            if (in_array("tailwindcss", $requiredPackages) && !file_exists(base_path("tailwind.config.js"))) {
+                warning("This preset requires Tailwind, but it looks like your app doesn't have a Tailwind configuration. You should set it up either by following the guide at https://tailwindcss.com/docs/guides/laravel or by installing a Laravel starter kit that includes it, such as Laravel Breeze: https://laravel.com/docs/11.x/starter-kits#breeze-and-blade");
+            }
         }
 
-        info("Finished!");
+        $viteInput = $preset->getViteInput();
+
+        if (count($viteInput) > 0) {
+            info("This preset requires the following lines need to be added to the Laravel input array in your vite.config.js file:");
+            foreach ($viteInput as $input) {
+                $this->line("    '$input',");
+            }
+
+            info("After adding these lines, don't forget to build for production:");
+            note("npm run build");
+        }
+
         info("To activate this preset, make sure the package config is published to your app and set the forum.frontend.preset value to '{$preset->getName()}'.");
     }
 }

--- a/src/Frontend/Presets/AbstractPreset.php
+++ b/src/Frontend/Presets/AbstractPreset.php
@@ -26,6 +26,14 @@ abstract class AbstractPreset
     }
 
     /**
+     * Returns lines that should be added to the input array in vite.config.js.
+     */
+    public static function getViteInput(): array
+    {
+        return [];
+    }
+
+    /**
      * Registers any components required by the preset.
      */
     public function register(): void
@@ -52,7 +60,7 @@ abstract class AbstractPreset
         return $this->getDestinationPath() . '/views';
     }
 
-    public function publish(FileSystem $filesystem): void
+    public function publish(Filesystem $filesystem): void
     {
         $destinationPath = $this->getDestinationPath();
         $filesystem->ensureDirectoryExists($destinationPath);

--- a/src/Frontend/Presets/BladeBootstrapPreset.php
+++ b/src/Frontend/Presets/BladeBootstrapPreset.php
@@ -21,6 +21,14 @@ class BladeBootstrapPreset extends AbstractPreset
         return FrontendStack::BLADE;
     }
 
+    public static function getViteInput(): array
+    {
+        return [
+            'resources/forum/blade-bootstrap/css/forum.css',
+            'resources/forum/blade-bootstrap/js/forum.js',
+        ];
+    }
+
     public static function getRequiredPackages(): array
     {
         return [

--- a/src/Frontend/Presets/BladeTailwindPreset.php
+++ b/src/Frontend/Presets/BladeTailwindPreset.php
@@ -38,6 +38,14 @@ class BladeTailwindPreset extends AbstractPreset
         ];
     }
 
+    public static function getViteInput(): array
+    {
+        return [
+            'resources/forum/blade-tailwind/css/forum.css',
+            'resources/forum/blade-tailwind/js/forum.js',
+        ];
+    }
+
     public function register(): void
     {
         $this->bladeComponentNamespace("TeamTeaTime\\Forum\\Frontend\\Presets\\BladeTailwind\\Components");

--- a/src/Frontend/Presets/LivewireTailwindPreset.php
+++ b/src/Frontend/Presets/LivewireTailwindPreset.php
@@ -46,6 +46,14 @@ class LivewireTailwindPreset extends AbstractPreset
         ];
     }
 
+    public static function getViteInput(): array
+    {
+        return [
+            'resources/forum/livewire-tailwind/css/forum.css',
+            'resources/forum/livewire-tailwind/js/forum.js',
+        ];
+    }
+
     public function register(): void
     {
         $this->bladeComponentNamespace("TeamTeaTime\\Forum\\Frontend\\Presets\\LivewireTailwind\\Components\\Blade");


### PR DESCRIPTION
This PR makes the preset installer additionally display the following:

* A prompt to configure Tailwind if the preset requires it and there's no `tailwind.config.js` yet
* A prompt to insert any Vite input lines specified by the preset into `vite.config.js`