### PR TITLE
Fix post route controller references in API routes

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -47,8 +47,8 @@ Route::prefix('thread')->name('thread.')->group(function () use ($authMiddleware
     });
 
     // Posts by thread
-    Route::get('{thread}/posts', [ThreadController::class, 'indexByThread'])->name('posts');
-    Route::post('{thread}/posts', [ThreadController::class, 'store'])->name('posts.store')->middleware($authMiddleware);
+    Route::get('{thread}/posts', [PostController::class, 'indexByThread'])->name('posts');
+    Route::post('{thread}/posts', [PostController::class, 'store'])->name('posts.store')->middleware($authMiddleware);
 });
 
 // Posts


### PR DESCRIPTION
Fix: Correct API post routes to use PostController instead of ThreadController
Summary

This PR fixes a bug in the API routes where ThreadController was incorrectly being used to handle post-related endpoints. Since these routes are explicitly dealing with posts, the correct controller should be PostController.

Changes Made

Updated the following routes:

// Before
Route::get('{thread}/posts', [ThreadController::class, 'indexByThread'])->name('posts');
Route::post('{thread}/posts', [ThreadController::class, 'store'])->name('posts.store')->middleware($authMiddleware);

// After
Route::get('{thread}/posts', [PostController::class, 'indexByThread'])->name('posts');
Route::post('{thread}/posts', [PostController::class, 'store'])->name('posts.store')->middleware($authMiddleware);

Why This Fix is Needed

The routes were incorrectly tied to ThreadController, causing  potential misbehavior.

Posts should logically be handled by PostController.

This aligns the API routes with proper RESTful conventions and improves maintainability.

Impact

No breaking changes to the API endpoints themselves ({thread}/posts remains the same).

Ensures the correct controller is responsible for post-related actions.
