### PR TITLE
Only show bulk script when needed and relevant post data

### DIFF
--- a/stubs/bootstrap/resources/views/forum/thread/show.blade.php
+++ b/stubs/bootstrap/resources/views/forum/thread/show.blade.php
@@ -349,12 +349,13 @@
     }
     </style>
 
+    @if ((count($posts) > 1 || $posts->currentPage() > 1) && count($selectablePosts) > 0)
     <script>
     new Vue({
         el: '.v-thread',
         name: 'Thread',
         data: {
-            posts: @json($posts),
+            posts: @json(['data' => $posts->map(fn($post) => ['id' => $post->id, 'sequence' => $post->sequence])]),
             selectablePosts: @json($selectablePosts),
             postActions: {
                 'delete': "{{ Forum::route('bulk.post.delete') }}",
@@ -394,4 +395,5 @@
         }
     });
     </script>
+    @endif
 @stop

--- a/stubs/tailwind/resources/views/forum/thread/show.blade.php
+++ b/stubs/tailwind/resources/views/forum/thread/show.blade.php
@@ -346,12 +346,13 @@
     }
     </style>
 
+    @if ((count($posts) > 1 || $posts->currentPage() > 1) && count($selectablePosts) > 0)
     <script>
     new Vue({
         el: '.v-thread',
         name: 'Thread',
         data: {
-            posts: @json($posts),
+            posts: @json(['data' => $posts->map(fn($post) => ['id' => $post->id, 'sequence' => $post->sequence])]),
             selectablePosts: @json($selectablePosts),
             postActions: {
                 'delete': "{{ Forum::route('bulk.post.delete') }}",
@@ -391,4 +392,5 @@
         }
     });
     </script>
+    @endif
 @stop


### PR DESCRIPTION
This PR removes the Vue-script for bulk actions when it's not needed.

It also removes unneeded post data  from the vue posts object.